### PR TITLE
Don't quit driver if environment contains TP_KEEP_DRIVER_SESSION variable

### DIFF
--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -35,21 +35,31 @@ namespace TestProject.OpenSDK.Drivers
     /// </summary>
     public class BaseDriver : RemoteWebDriver, ITestProjectDriver
     {
+        private const string KeepSessionEnvironmentVariable = "TP_KEEP_DRIVER_SESSION";
+        private static readonly bool KeepDriverSession;
+
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
         /// </summary>
         public bool IsRunning { get; private set; }
 
-        private DriverShutdownThread driverShutdownThread;
+        private readonly DriverShutdownThread driverShutdownThread;
 
-        private string sessionId;
+        private readonly string sessionId;
 
-        private CustomHttpCommandExecutor commandExecutor;
+        private readonly CustomHttpCommandExecutor commandExecutor;
 
         /// <summary>
         /// Logger instance for this class.
         /// </summary>
         private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
+
+        static BaseDriver()
+        {
+            var keepSessionVariable = Environment.GetEnvironmentVariable(KeepSessionEnvironmentVariable);
+            bool.TryParse(keepSessionVariable, out bool result);
+            KeepDriverSession = result;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseDriver"/> class.
@@ -143,7 +153,11 @@ namespace TestProject.OpenSDK.Drivers
 
             this.IsRunning = false;
 
-            base.Quit();
+            // Need to keep session alive if TP_KEEP_DRIVER_SESSION was specified.
+            if (!KeepDriverSession)
+            {
+                base.Quit();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
OpenSDK has logic that closes the driver when process exits.
However we cannot quit the driver if executing from the platform, because that will break other tests.
To prevent calls to driver.Quit() from killing the session, agent specifies an environment variable.
SDK should respect this flag and not quit the session if it is set.