### PR TITLE
infer custom test name

### DIFF
--- a/TestProject.OpenSDK.Tests/Examples/Frameworks/MSTest/InferredReportTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Frameworks/MSTest/InferredReportTest.cs
@@ -43,7 +43,7 @@ namespace TestProject.OpenSDK.Tests.Examples.Frameworks.MSTest
         /// <summary>
         /// An example test logging in to the TestProject demo application with Chrome.
         /// </summary>
-        [TestMethod]
+        [TestMethod("MSTest Example Using Chrome Driver")]
         public void ExampleTestUsingChromeDriver()
         {
             this.driver.Navigate().GoToUrl("https://example.testproject.io");

--- a/TestProject.OpenSDK.Tests/Examples/Frameworks/NUnit/InferredReportTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Frameworks/NUnit/InferredReportTest.cs
@@ -43,7 +43,7 @@ namespace TestProject.OpenSDK.Tests.Examples.Frameworks.NUnit
         /// <summary>
         /// An example test logging in to the TestProject demo application with Chrome.
         /// </summary>
-        [Test]
+        [Test(Description = "NUnit Example Using Chrome Driver")]
         public void ExampleTestUsingChromeDriver()
         {
             this.driver.Navigate().GoToUrl("https://example.testproject.io");

--- a/TestProject.OpenSDK.Tests/Examples/Frameworks/XUnit/InferredReportTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Frameworks/XUnit/InferredReportTest.cs
@@ -28,7 +28,7 @@ namespace TestProject.OpenSDK.Tests.Examples.Frameworks.XUnit
         /// <summary>
         /// An example test logging in to the TestProject demo application with Chrome.
         /// </summary>
-        [Fact]
+        [Fact(DisplayName = "XUnit Example Using Chrome Driver")]
         public void ExampleTestUsingChromeDriver()
         {
             ChromeDriver driver = new ChromeDriver();  // Project and job names are inferred.

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/IMethodAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/IMethodAnalyzer.cs
@@ -36,5 +36,12 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         /// <param name="method">The method to be analyzed.</param>
         /// <returns>True if the method is run inside a setup hook, false otherwise.</returns>
         bool IsSetupMethod(MethodBase method);
+
+        /// <summary>
+        /// Gets the test name, taking into account custom display names specified by the user.
+        /// </summary>
+        /// <param name="method">The method to be analyzed.</param>
+        /// <returns>Test name, or null if method not supported by this analyzer.</returns>
+        string GetTestName(MethodBase method);
     }
 }

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/MSTestAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/MSTestAnalyzer.cs
@@ -28,6 +28,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         private const string SetUpAttribute = "TestInitialize";
         private const string TestClassAttribute = "TestClass";
         private const string MSTestFrameworkNamespace = "Microsoft.VisualStudio.TestTools.UnitTesting";
+        private const string TestNameProperty = "DisplayName";
 
         /// <summary>
         /// Determines whether or not the class containing the method that is run belongs to MSTest.
@@ -53,6 +54,16 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
             return method.GetCustomAttributes(true).Any(a => a.GetType().Name.Contains(SetUpAttribute)
             && a.GetType().Namespace.Equals(MSTestFrameworkNamespace))
                 && method.DeclaringType.GetCustomAttributes(true).Any(a => a.GetType().Name.Contains(TestClassAttribute) && a.GetType().Namespace.Equals(MSTestFrameworkNamespace));
+        }
+
+        /// <inheritdoc cref="IMethodAnalyzer"/>
+        public string GetTestName(MethodBase method)
+        {
+            // Attribute has a DisplayName property set this way: [TestMethod("name")]
+            var attribute = method.GetCustomAttributes(true).FirstOrDefault(a =>
+                a.GetType().Name.Contains(TestAttribute)
+                && a.GetType().Namespace.Equals(MSTestFrameworkNamespace));
+            return attribute?.GetType().GetProperty(TestNameProperty)?.GetValue(attribute)?.ToString();
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/NUnitAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/NUnitAnalyzer.cs
@@ -27,6 +27,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         private const string TestAttribute = "TestAttribute";
         private const string SetUpAttribute = "SetUpAttribute";
         private const string NUnitFrameworkNamespace = "NUnit.Framework";
+        private const string TestNameProperty = "Description";
 
         /// <summary>
         /// Determines whether or not the class containing the method that is run belongs to NUnit.
@@ -56,6 +57,16 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         {
             // NUnit setup methods are identified by [SetUpAttribute] on the method
             return method.GetCustomAttributes(true).Any(a => a.GetType().Name.Contains(SetUpAttribute));
+        }
+
+        /// <inheritdoc cref="IMethodAnalyzer"/>
+        public string GetTestName(MethodBase method)
+        {
+            // Attribute has a Description property set this way: [TestMethod(Description = "name")]
+            var attribute = method.GetCustomAttributes(true)
+                .FirstOrDefault(a => a.GetType().Name.Equals(TestAttribute)
+                                     && a.GetType().Namespace.Equals(NUnitFrameworkNamespace));
+            return attribute?.GetType().GetProperty(TestNameProperty)?.GetValue(attribute)?.ToString();
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
@@ -46,7 +46,9 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         /// <returns>The inferred test method name.</returns>
         public string GetInferredTestName()
         {
-            return this.TryDetectTestMethod().Name;
+            var testMethod = this.TryDetectTestMethod();
+            return this.analyzers.Select(a => a.GetTestName(testMethod)).FirstOrDefault(n => !string.IsNullOrEmpty(n))
+                ?? testMethod.Name;
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/XUnitAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/XUnitAnalyzer.cs
@@ -25,6 +25,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
     public class XUnitAnalyzer : IMethodAnalyzer
     {
         private const string XUnitNamespace = "XUnit";
+        private const string TestNameProperty = "DisplayName";
         private static readonly string[] AttributeNames = { "Fact", "Theory" };
 
         /// <summary>
@@ -46,6 +47,17 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         {
             // xUnit.NET does not support setup methods, so this is always false.
             return false;
+        }
+
+        /// <inheritdoc cref="IMethodAnalyzer"/>
+        public string GetTestName(MethodBase method)
+        {
+            // Attribute has a DisplayName property set this way: [TestMethod(DisplayName = "name")]
+            var attribute = method.GetCustomAttributes(true)
+                .FirstOrDefault(a => AttributeNames.Contains(a.GetType().Name) &&
+                          (a.GetType().Namespace?.Equals(XUnitNamespace) ?? false));
+
+            return attribute?.GetType().GetProperty(TestNameProperty)?.GetValue(attribute)?.ToString();
         }
     }
 }


### PR DESCRIPTION
This PR is intended to solve issue https://github.com/testproject-io/csharp-opensdk/issues/78.

The goal is to parse test name from custom values that users will specify in their test attributes:
- **NUnit:** `[Test(DisplayName="custom test name)]`
- **XUnit:** `[Fact(DisplayName="custom test name")]` or `[Theory(DisplayName="custom test name"]`
- **MSTest:** `[TestMethod("custom test name")]`