### PR TITLE
run shutdown hooks in specific order

### DIFF
--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -97,7 +97,6 @@ namespace TestProject.OpenSDK.Drivers
 
             // Add shutdown hook for gracefully shutting down the driver
             this.driverShutdownThread = new DriverShutdownThread(this);
-            AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) => this.driverShutdownThread.RunThread();
 
             if (StackTraceHelper.Instance.TryDetectSpecFlow())
             {
@@ -133,7 +132,7 @@ namespace TestProject.OpenSDK.Drivers
             if (this.IsRunning)
             {
                 // Avoid performing the graceful shutdown more than once
-                AppDomain.CurrentDomain.ProcessExit -= (sender, eventArgs) => this.driverShutdownThread.RunThread();
+                this.driverShutdownThread.Dispose();
 
                 this.Stop();
             }

--- a/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
@@ -17,14 +17,18 @@
 namespace TestProject.OpenSDK.Internal.Helpers.Threading
 {
     using NLog;
+    using System;
     using TestProject.OpenSDK.Drivers;
 
     /// <summary>
     /// A class that spawns a separate thread to gracefully stop a browser session.
     /// </summary>
-    public class DriverShutdownThread : BaseThread
+    public class DriverShutdownThread : BaseThread, IDisposable
     {
+        private static int priorityCounter = 0;
+
         private ITestProjectDriver driver;
+        private int priority;
 
         private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
 
@@ -36,6 +40,8 @@ namespace TestProject.OpenSDK.Internal.Helpers.Threading
             : base()
         {
             this.driver = driver;
+            this.priority = priorityCounter++;
+            ShutdownThreadHelper.Instance.Register(this.priority, this);
         }
 
         /// <summary>
@@ -48,6 +54,12 @@ namespace TestProject.OpenSDK.Internal.Helpers.Threading
             {
                 this.driver.Stop();
             }
+        }
+
+        /// <inheritdoc cref="IDisposable"/>
+        public void Dispose()
+        {
+            ShutdownThreadHelper.Instance.Unregister(this.priority);
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/Helpers/Threading/ShutdownThreadHelper.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/ShutdownThreadHelper.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="ShutdownThreadHelper.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Helpers.Threading
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+
+    /// <summary>
+    /// Helper for calling shutdown thread actions in-order.
+    /// Actions are executed in increased priority
+    /// </summary>
+    internal class ShutdownThreadHelper
+    {
+        private static readonly Lazy<ShutdownThreadHelper> Lazy = new Lazy<ShutdownThreadHelper>(() => new ShutdownThreadHelper());
+
+        private readonly ConcurrentDictionary<int, BaseThread> threads;
+
+        /// <summary>
+        /// Gets the instance of this class.
+        /// </summary>
+        public static ShutdownThreadHelper Instance => Lazy.Value;
+
+        private ShutdownThreadHelper()
+        {
+            this.threads = new ConcurrentDictionary<int, BaseThread>();
+            AppDomain.CurrentDomain.ProcessExit += this.OnProcessExit;
+        }
+
+        /// <summary>
+        /// Register a BaseThread to be executed when process shuts down.
+        /// </summary>
+        /// <param name="priority">Priority of thread execution.</param>
+        /// <param name="thread">Thread to register.</param>
+        /// <exception cref="IndexOutOfRangeException">If registering a thread with an occupied priority.</exception>
+        public void Register(int priority, BaseThread thread)
+        {
+            if (this.threads.ContainsKey(priority))
+            {
+                throw new IndexOutOfRangeException("Attempted to register a thread with a priority already in use.");
+            }
+
+            this.threads[priority] = thread;
+        }
+
+        /// <summary>
+        /// Un-registers a thread with requested priority. If it isn't registered nothing happens.
+        /// </summary>
+        /// <param name="priority">Priority to unregister.</param>
+        public void Unregister(int priority)
+        {
+            this.threads.TryRemove(priority, out _);
+        }
+
+        private void OnProcessExit(object sender, EventArgs e)
+        {
+            foreach (var thread in this.threads.OrderBy((kv) => kv.Key).Select(kv => kv.Value))
+            {
+                thread.RunThread();
+            }
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Helpers/Threading/SocketClosingThread.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/SocketClosingThread.cs
@@ -17,12 +17,13 @@
 namespace TestProject.OpenSDK.Internal.Helpers.Threading
 {
     using NLog;
+    using System;
     using TestProject.OpenSDK.Internal.Tcp;
 
     /// <summary>
     /// A class that spawns a separate thread to gracefully close an open development socket.
     /// </summary>
-    public class SocketClosingThread : BaseThread
+    public class SocketClosingThread : BaseThread, IDisposable
     {
         private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
 
@@ -32,6 +33,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.Threading
         public SocketClosingThread()
             : base()
         {
+            ShutdownThreadHelper.Instance.Register(int.MaxValue, this);
         }
 
         /// <summary>
@@ -41,6 +43,12 @@ namespace TestProject.OpenSDK.Internal.Helpers.Threading
         {
             Logger.Info("Closing socket gracefully...");
             SocketManager.GetInstance().CloseSocket();
+        }
+
+        /// <inheritdoc cref="IDisposable"/>
+        public void Dispose()
+        {
+            ShutdownThreadHelper.Instance.Unregister(int.MaxValue);
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/Tcp/SocketManager.cs
+++ b/TestProject.OpenSDK/Internal/Tcp/SocketManager.cs
@@ -53,7 +53,6 @@ namespace TestProject.OpenSDK.Internal.Tcp
         private SocketManager()
         {
             socketClosingThread = new SocketClosingThread();
-            AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) => socketClosingThread.RunThread();
         }
 
         /// <summary>


### PR DESCRIPTION
While executing multiple tests, sometimes the last few steps or last test name are not reported.
The cause of this is because the shutdown hooks run out-of-order.
The order should be as follows:
1. All the DriverShutdownThreads
2. The one SocketClosingThread

To solve this cleanly, i've added a class that will run all shutdown threads based on their requested priority, which will allow us to make sure the order is maintained.

Related issue: https://github.com/testproject-io/csharp-opensdk/issues/77