### PR TITLE
Fix broken project, job and test inferring logic for XUnit

### DIFF
--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/MSTestStackTraceHelperTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/MSTestStackTraceHelperTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="StackTraceHelperTest.cs" company="TestProject">
+﻿// <copyright file="MSTestStackTraceHelperTest.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,10 +20,10 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
 
     /// <summary>
-    /// Class containing unit tests for the <see cref="StackTraceHelper"/> class.
+    /// Class containing unit tests for the <see cref="StackTraceHelper"/> class using MSTest.
     /// </summary>
     [TestClass]
-    public class StackTraceHelperTest
+    public class MSTestStackTraceHelperTest
     {
         private string projectNameFromTestInitialize;
         private string jobNameFromTestInitialize;
@@ -50,6 +50,17 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
         }
 
         /// <summary>
+        /// Inferring the current test name should return the expected value when using a description in the annotation.
+        /// </summary>
+        [TestMethod("Custom test name")]
+        public void GetInferredTestName__UsingCustomTestName_CheckResult_ShouldEqualCurrentTestMethodName()
+        {
+            string testName = StackTraceHelper.Instance.GetInferredTestName();
+
+            Assert.AreEqual("Custom test name", testName);
+        }
+
+        /// <summary>
         /// Inferring the job name should return the expected value.
         /// </summary>
         [TestMethod]
@@ -57,7 +68,7 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
         {
             string jobName = StackTraceHelper.Instance.GetInferredJobName();
 
-            Assert.AreEqual("StackTraceHelperTest", jobName);
+            Assert.AreEqual("MSTestStackTraceHelperTest", jobName);
         }
 
         /// <summary>
@@ -86,7 +97,7 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
         [TestMethod]
         public void CheckInferredJobNameFromTestInitialize_ShouldEqualCurrentTestClass()
         {
-            Assert.AreEqual("StackTraceHelperTest", this.jobNameFromTestInitialize);
+            Assert.AreEqual("MSTestStackTraceHelperTest", this.jobNameFromTestInitialize);
         }
     }
 }

--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/NUnitStackTraceHelperTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/NUnitStackTraceHelperTest.cs
@@ -1,0 +1,103 @@
+﻿// <copyright file="NUnitStackTraceHelperTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
+{
+    using NUnit.Framework;
+    using TestProject.OpenSDK.Internal.CallStackAnalysis;
+
+    /// <summary>
+    /// Class containing unit tests for the <see cref="StackTraceHelper"/> class using NUnit.
+    /// </summary>
+    [TestFixture]
+    public class NUnitStackTraceHelperTest
+    {
+        private string projectNameFromSetUp;
+        private string jobNameFromSetUp;
+
+        /// <summary>
+        /// Infer the project and job name from within a [SetUp] method for later verification.
+        /// </summary>
+        [SetUp]
+        public void GetInferredProjectAndJobName()
+        {
+            this.projectNameFromSetUp = StackTraceHelper.Instance.GetInferredProjectName();
+            this.jobNameFromSetUp = StackTraceHelper.Instance.GetInferredJobName();
+        }
+
+        /// <summary>
+        /// Inferring the current test name should return the expected value.
+        /// </summary>
+        [Test]
+        public void GetInferredTestName_CheckResult_ShouldEqualCurrentTestMethodName()
+        {
+            string testName = StackTraceHelper.Instance.GetInferredTestName();
+
+            Assert.AreEqual("GetInferredTestName_CheckResult_ShouldEqualCurrentTestMethodName", testName);
+        }
+
+        /// <summary>
+        /// Inferring the current test name should return the expected value when using a description in the annotation.
+        /// </summary>
+        [Test(Description ="Custom test name")]
+        public void GetInferredTestName__UsingCustomTestName_CheckResult_ShouldEqualCurrentTestMethodName()
+        {
+            string testName = StackTraceHelper.Instance.GetInferredTestName();
+
+            Assert.AreEqual("Custom test name", testName);
+        }
+
+        /// <summary>
+        /// Inferring the job name should return the expected value.
+        /// </summary>
+        [Test]
+        public void GetInferredJobName_CheckResult_ShouldEqualCurrentTestClass()
+        {
+            string jobName = StackTraceHelper.Instance.GetInferredJobName();
+
+            Assert.AreEqual("NUnitStackTraceHelperTest", jobName);
+        }
+
+        /// <summary>
+        /// Inferring the project name should return the expected value.
+        /// </summary>
+        [Test]
+        public void GetInferredProjectName_CheckResult_ShouldEqualFinalPartOfCurrentNamespace()
+        {
+            string projectName = StackTraceHelper.Instance.GetInferredProjectName();
+
+            Assert.AreEqual("CallStackAnalysis", projectName);
+        }
+
+        /// <summary>
+        /// Inferring the project name in a [SetUp] method should return the expected value.
+        /// </summary>
+        [Test]
+        public void CheckInferredProjectNameFromTestInitialize_ShouldEqualFinalPartOfCurrentNamespace()
+        {
+            Assert.AreEqual("CallStackAnalysis", this.projectNameFromSetUp);
+        }
+
+        /// <summary>
+        /// Inferring the job name in a [SetUp] method should return the expected value.
+        /// </summary>
+        [Test]
+        public void CheckInferredJobNameFromTestInitialize_ShouldEqualCurrentTestClass()
+        {
+            Assert.AreEqual("NUnitStackTraceHelperTest", this.jobNameFromSetUp);
+        }
+    }
+}

--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/XUnitStackTraceHelperTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/XUnitStackTraceHelperTest.cs
@@ -1,0 +1,71 @@
+﻿// <copyright file="XUnitStackTraceHelperTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
+{
+    using TestProject.OpenSDK.Internal.CallStackAnalysis;
+    using Xunit;
+
+    /// <summary>
+    /// Class containing unit tests for the <see cref="StackTraceHelper"/> class using xUnit.NET.
+    /// </summary>
+    public class XUnitStackTraceHelperTest
+    {
+        /// <summary>
+        /// Inferring the current test name should return the expected value.
+        /// </summary>
+        [Fact]
+        public void GetInferredTestName_CheckResult_ShouldEqualCurrentTestMethodName()
+        {
+            string testName = StackTraceHelper.Instance.GetInferredTestName();
+
+            Assert.Equal("GetInferredTestName_CheckResult_ShouldEqualCurrentTestMethodName", testName);
+        }
+
+        /// <summary>
+        /// Inferring the current test name should return the expected value when using a description in the annotation.
+        /// </summary>
+        [Fact(DisplayName ="Custom test name")]
+        public void GetInferredTestName__UsingCustomTestName_CheckResult_ShouldEqualCurrentTestMethodName()
+        {
+            string testName = StackTraceHelper.Instance.GetInferredTestName();
+
+            Assert.Equal("Custom test name", testName);
+        }
+
+        /// <summary>
+        /// Inferring the job name should return the expected value.
+        /// </summary>
+        [Fact]
+        public void GetInferredJobName_CheckResult_ShouldEqualCurrentTestClass()
+        {
+            string jobName = StackTraceHelper.Instance.GetInferredJobName();
+
+            Assert.Equal("XUnitStackTraceHelperTest", jobName);
+        }
+
+        /// <summary>
+        /// Inferring the project name should return the expected value.
+        /// </summary>
+        [Fact]
+        public void GetInferredProjectName_CheckResult_ShouldEqualFinalPartOfCurrentNamespace()
+        {
+            string projectName = StackTraceHelper.Instance.GetInferredProjectName();
+
+            Assert.Equal("CallStackAnalysis", projectName);
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/XUnitAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/XUnitAnalyzer.cs
@@ -24,9 +24,9 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
     /// </summary>
     public class XUnitAnalyzer : IMethodAnalyzer
     {
-        private const string XUnitNamespace = "XUnit";
+        private const string XUnitNamespace = "Xunit";
         private const string TestNameProperty = "DisplayName";
-        private static readonly string[] AttributeNames = { "Fact", "Theory" };
+        private static readonly string[] AttributeNames = { "FactAttribute", "TheoryAttribute" };
 
         /// <summary>
         /// Determines whether or not the class containing the method that is run belongs to XUnit.


### PR DESCRIPTION
This PR fixes an issue with broken project, job and test name inferring for xUnit.NET.