### PR TITLE
Fix linting warnings related to import statement order

### DIFF
--- a/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
@@ -16,8 +16,8 @@
 
 namespace TestProject.OpenSDK.Internal.Helpers.Threading
 {
-    using NLog;
     using System;
+    using NLog;
     using TestProject.OpenSDK.Drivers;
 
     /// <summary>

--- a/TestProject.OpenSDK/Internal/Helpers/Threading/SocketClosingThread.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/SocketClosingThread.cs
@@ -16,8 +16,8 @@
 
 namespace TestProject.OpenSDK.Internal.Helpers.Threading
 {
-    using NLog;
     using System;
+    using NLog;
     using TestProject.OpenSDK.Internal.Tcp;
 
     /// <summary>


### PR DESCRIPTION
This PR fixes a couple of warnings related to import statement order issued by .NETAnalyzer