### PR TITLE
Fix/w3c compatibility issues

### DIFF
--- a/TestProject.OpenSDK.Tests/FlowTests/ChromeW3CCompatibilityTest.cs
+++ b/TestProject.OpenSDK.Tests/FlowTests/ChromeW3CCompatibilityTest.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="ChromeW3CCompatibilityTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.FlowTests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium;
+    using TestProject.OpenSDK.Drivers.Web;
+
+    /// <summary>
+    /// This class contains a test using the TestProject C# SDK with Chrome and some commands to check
+    /// that W3C compatibility is set correctly (e.g., using By.Id, using .Displayed).
+    /// </summary>
+    [TestClass]
+    public class ChromeW3CCompatibilityTest
+    {
+        /// <summary>
+        /// The TestProject ChromeDriver instance to be used in this test class.
+        /// </summary>
+        private ChromeDriver driver;
+
+        /// <summary>
+        /// Starts a headless Chrome browser before each test.
+        /// </summary>
+        [TestInitialize]
+        public void StartBrowser()
+        {
+            OpenQA.Selenium.Chrome.ChromeOptions chromeOptions = new OpenQA.Selenium.Chrome.ChromeOptions();
+            chromeOptions.AddArgument("--headless");
+            this.driver = new ChromeDriver(chromeOptions: chromeOptions, projectName: "CI - C#");
+        }
+
+        /// <summary>
+        /// An example test logging in to the TestProject demo application with Chrome.
+        /// Uses some commands to check W3C compatibility directly.
+        /// </summary>
+        [TestMethod]
+        public void ExampleTestUsingChromeDriver()
+        {
+            this.driver.Navigate().GoToUrl("https://example.testproject.io");
+            this.driver.FindElement(By.CssSelector("#name")).SendKeys("John Smith");
+            this.driver.FindElement(By.CssSelector("#password")).SendKeys("12345");
+            this.driver.FindElement(By.CssSelector("#login")).Click();
+
+            Assert.IsTrue(this.driver.FindElement(By.CssSelector("#greetings")).Displayed);
+        }
+
+        /// <summary>
+        /// Closes the browser and ends the development session after each test.
+        /// </summary>
+        [TestCleanup]
+        public void CloseBrowser()
+        {
+            this.driver.Quit();
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
@@ -18,7 +18,9 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
     using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// A custom commands executor for Selenium drivers.
@@ -50,6 +52,14 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         public CustomHttpCommandExecutor(Uri addressOfRemoteServer, bool disableReports, TimeSpan remoteConnectionTimeout)
             : base(addressOfRemoteServer, remoteConnectionTimeout)
         {
+            // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
+            // associated with the base HttpCommandExecutor to the W3C command info repository (default is OSS).
+            if (AgentClient.GetInstance().IsInW3CMode())
+            {
+                FieldInfo commandInfoRepositoryField = typeof(HttpCommandExecutor).GetField("commandInfoRepository", BindingFlags.Instance | BindingFlags.NonPublic);
+                commandInfoRepositoryField.SetValue(this, new W3CWireProtocolCommandInfoRepository());
+            }
+
             this.ReportingCommandExecutor = new ReportingCommandExecutor(this, disableReports);
         }
 

--- a/TestProject.OpenSDK/Internal/Helpers/ExtensionMethods.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/ExtensionMethods.cs
@@ -19,6 +19,7 @@ namespace TestProject.OpenSDK.Internal.Helpers
     using System;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// This class contains custom extension methods implementing SDK specific business logic.
@@ -62,6 +63,16 @@ namespace TestProject.OpenSDK.Internal.Helpers
             {
                 return originalUri;
             }
+        }
+
+        /// <summary>
+        /// Checks whether the session associated with the given AgentClient is a W3C compatible session.
+        /// </summary>
+        /// <param name="agentClient">The <see cref="AgentClient"/> that we want to check W3C compatibility for.</param>
+        /// <returns>True if the session is W3C compatible, false otherwise.</returns>
+        public static bool IsInW3CMode(this AgentClient agentClient)
+        {
+            return agentClient.AgentSession.Dialect.Equals("W3C");
         }
     }
 }


### PR DESCRIPTION
This PR fixes W3C compatibility issues that caused a number of problems when using, for example, `By.Id` locators and Selenium commands that invoke the `executeScript` WebDriver W3C command.