### PR TITLE
Fix/keep session test name

### DIFF
--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -36,9 +36,6 @@ namespace TestProject.OpenSDK.Drivers
     /// </summary>
     public class BaseDriver : RemoteWebDriver, ITestProjectDriver
     {
-        private const string KeepSessionEnvironmentVariable = "TP_KEEP_DRIVER_SESSION";
-        private static readonly bool KeepDriverSession;
-
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
         /// </summary>
@@ -57,9 +54,6 @@ namespace TestProject.OpenSDK.Drivers
 
         static BaseDriver()
         {
-            var keepSessionVariable = Environment.GetEnvironmentVariable(KeepSessionEnvironmentVariable);
-            bool.TryParse(keepSessionVariable, out bool result);
-            KeepDriverSession = result;
         }
 
         /// <summary>
@@ -159,11 +153,7 @@ namespace TestProject.OpenSDK.Drivers
 
             this.IsRunning = false;
 
-            // Need to keep session alive if TP_KEEP_DRIVER_SESSION was specified.
-            if (!KeepDriverSession)
-            {
-                base.Quit();
-            }
+            base.Quit();
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
@@ -86,12 +86,12 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         {
             // The Selenium HttpCommandExecutor modifies the command parameters, removing properties we need along the way
             // We want to use the original command parameters when reporting, not the modified one after command execution.
-            Dictionary<string, object> originalParameters = new Dictionary<string, object>(commandToExecute.Parameters);
+            var originalParameters = new Dictionary<string, object>(commandToExecute.Parameters);
 
             Response response = base.Execute(commandToExecute);
 
             // Create a command to report using the original parameters instead of the modified ones.
-            Command commandToReport = new Command(commandToExecute.SessionId, commandToExecute.Name, originalParameters);
+            var commandToReport = new Command(commandToExecute.SessionId, commandToExecute.Name, originalParameters);
 
             if (!skipReporting)
             {

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
@@ -19,6 +19,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
     using TestProject.OpenSDK.Internal.Rest;
 
@@ -28,6 +29,18 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
     /// </summary>
     public class CustomHttpCommandExecutor : HttpCommandExecutor, ITestProjectCommandExecutor
     {
+        private const string KeepSessionEnvironmentVariable = "TP_KEEP_DRIVER_SESSION";
+
+
+        private static readonly bool KeepDriverSession;
+
+        static CustomHttpCommandExecutor()
+        {
+            var keepSessionVariable = Environment.GetEnvironmentVariable(KeepSessionEnvironmentVariable);
+            bool.TryParse(keepSessionVariable, out bool result);
+            KeepDriverSession = result;
+        }
+
         /// <summary>
         /// Object responsible for executing reporting to TestProject.
         /// </summary>
@@ -88,7 +101,17 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
             // We want to use the original command parameters when reporting, not the modified one after command execution.
             var originalParameters = new Dictionary<string, object>(commandToExecute.Parameters);
 
-            Response response = base.Execute(commandToExecute);
+            Response response;
+
+            // Need to keep session alive if TP_KEEP_DRIVER_SESSION was specified.
+            if (commandToExecute.Name.Equals(DriverCommand.Quit) && KeepDriverSession)
+            {
+                response = new Response { SessionId = commandToExecute.SessionId.ToString(), Status = WebDriverResult.Success };
+            }
+            else
+            {
+                response = base.Execute(commandToExecute);
+            }
 
             // Create a command to report using the original parameters instead of the modified ones.
             var commandToReport = new Command(commandToExecute.SessionId, commandToExecute.Name, originalParameters);


### PR DESCRIPTION
When TP_KEEP_DRIVER_SESSION environment variable is specified, quit is never invoked.
This works fine for keeping the session alive, but causes us to skip reporting of Quit command, which in turn skips reporting test name.
To fix this, checking of the variable should be moved to the command executor and only the command execution itself should be skipped.
Fixed issue: https://github.com/testproject-io/csharp-opensdk/issues/103