### PR TITLE
Feature/android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ TestProject.OpenSDK.Drivers
 │   ├── InternetExplorerDriver
 │   ├── SafariDriver
 │   └── RemoteWebDriver
+├── Android
+│   └── AndroidDriver
 ├── Generic
 │   └── GenericDriver
 ```
@@ -234,13 +236,19 @@ A working example project can be found [here](https://github.com/testproject-io/
 More usage examples for the OpenSDK can be found [here](https://github.com/testproject-io/csharp-opensdk/tree/main/TestProject.OpenSDK.Tests/Examples):
 
 * Drivers
-  * [Chrome Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/ChromeDriverTest.cs)
-  * [Edge Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/EdgeDriverTest.cs)
-  * [Firefox Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/FirefoxDriverTest.cs)
-  * [Internet Explorer Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/InternetExplorerDriverTest.cs)
-  * [Safari Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/SafariDriverTest.cs)
-  * [Remote Web Driver Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/RemoteWebDriverTest.cs)
-  * [Generic Driver Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/GenericDriverTest.cs)
+  * Web
+    * [Chrome Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/ChromeDriverTest.cs)
+    * [Edge Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/EdgeDriverTest.cs)
+    * [Firefox Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/FirefoxDriverTest.cs)
+    * [Internet Explorer Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/InternetExplorerDriverTest.cs)
+    * [Safari Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/SafariDriverTest.cs)
+    * [Remote Web Driver Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/RemoteWebDriverTest.cs)
+  * Android
+    * [Android native test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverTest.cs)
+    * [Android native app](https://github.com/testproject-io/android-demo-app)
+    * [Web test on mobile Chrome](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverChromeTest.cs)
+  * Generic
+    * [Generic Driver Test](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Drivers/GenericDriverTest.cs)
 * Frameworks
   * MSTest
     * [Inferred Report](https://github.com/testproject-io/csharp-opensdk/blob/main/TestProject.OpenSDK.Tests/Examples/Frameworks/MSTest/InferredReportTest.cs)

--- a/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverChromeTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverChromeTest.cs
@@ -1,0 +1,88 @@
+﻿// <copyright file="AndroidDriverChromeTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.Examples.Drivers
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Enums;
+    using OpenQA.Selenium.Remote;
+    using OpenQA.Selenium.Support.UI;
+    using TestProject.OpenSDK.Drivers.Android;
+    using TestProject.OpenSDK.Internal.Exceptions;
+
+    /// <summary>
+    /// This class contains examples of using the TestProject C# SDK with a Chrome browser on Android.
+    /// </summary>
+    [TestClass]
+    public class AndroidDriverChromeTest
+    {
+        private readonly string dutUdid = Environment.GetEnvironmentVariable("TP_ANDROID_DUT_UDID");
+
+        /// <summary>
+        /// The TestProject AndroidDriver instance to be used in this test class.
+        /// </summary>
+        private AndroidDriver<AppiumWebElement> driver;
+
+        /// <summary>
+        /// Starts an Android driver with required AppiumOptions before each test.
+        /// </summary>
+        [TestInitialize]
+        public void StartDriver()
+        {
+            if (this.dutUdid == null)
+            {
+                throw new SdkException("TP_ANDROID_DUT_UDID variable was not set before the start of the test.");
+            }
+
+            AppiumOptions appiumOptions = new AppiumOptions();
+
+            appiumOptions.AddAdditionalCapability(MobileCapabilityType.PlatformName, MobilePlatform.Android);
+            appiumOptions.AddAdditionalCapability(MobileCapabilityType.Udid, this.dutUdid);
+
+            appiumOptions.AddAdditionalCapability(CapabilityType.BrowserName, MobileBrowserType.Chrome);
+            appiumOptions.AddAdditionalCapability(MobileCapabilityType.DeviceName, "Pixel_3a_API_29_x86 [emulator-5554]");
+
+            this.driver = new AndroidDriver<AppiumWebElement>(appiumOptions: appiumOptions);
+        }
+
+        /// <summary>
+        /// An example test logging in to the TestProject native demo application on Android.
+        /// </summary>
+        [TestMethod]
+        public void ExampleTestUsingAndroidChromeDriver()
+        {
+            this.driver.Navigate().GoToUrl("https://example.testproject.io");
+
+            this.driver.FindElement(By.CssSelector("#name")).SendKeys("John Smith");
+            this.driver.FindElement(By.CssSelector("#password")).SendKeys("12345");
+            this.driver.FindElement(By.CssSelector("#login")).Click();
+
+            Assert.IsTrue(this.driver.FindElement(By.CssSelector("#greetings")).Displayed);
+        }
+
+        /// <summary>
+        /// Closes the browser and ends the development session after each test.
+        /// </summary>
+        [TestCleanup]
+        public void CloseBrowser()
+        {
+            this.driver.Quit();
+        }
+    }
+}

--- a/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverTest.cs
@@ -1,0 +1,93 @@
+﻿// <copyright file="AndroidDriverTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.Examples.Drivers
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Enums;
+    using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Drivers.Android;
+    using TestProject.OpenSDK.Internal.Exceptions;
+
+    /// <summary>
+    /// This class contains examples of using the TestProject C# SDK with a native Android app.
+    /// </summary>
+    [TestClass]
+    public class AndroidDriverTest
+    {
+        private readonly string dutUdid = Environment.GetEnvironmentVariable("TP_ANDROID_DUT_UDID");
+
+        private readonly string autPackageName = Environment.GetEnvironmentVariable("TP_ANDROID_AUT_PACKAGE");
+
+        private readonly string autActivityName = Environment.GetEnvironmentVariable("TP_ANDROID_AUT_ACTIVITY");
+
+        /// <summary>
+        /// The TestProject AndroidDriver instance to be used in this test class.
+        /// </summary>
+        private AndroidDriver<AppiumWebElement> driver;
+
+        /// <summary>
+        /// Starts an Android driver with required AppiumOptions before each test.
+        /// </summary>
+        [TestInitialize]
+        public void StartDriver()
+        {
+            if (this.autActivityName == null || this.autPackageName == null || this.dutUdid == null)
+            {
+                throw new SdkException("Not all required environment variables were set before the start of the test.");
+            }
+
+            AppiumOptions appiumOptions = new AppiumOptions();
+
+            appiumOptions.AddAdditionalCapability(MobileCapabilityType.PlatformName, MobilePlatform.Android);
+            appiumOptions.AddAdditionalCapability(MobileCapabilityType.Udid, this.dutUdid);
+
+            appiumOptions.AddAdditionalCapability(CapabilityType.BrowserName, string.Empty);
+            appiumOptions.AddAdditionalCapability(MobileCapabilityType.DeviceName, "Pixel_3a_API_29_x86 [emulator-5554]");
+            appiumOptions.AddAdditionalCapability(AndroidMobileCapabilityType.AppPackage, this.autPackageName);
+            appiumOptions.AddAdditionalCapability(AndroidMobileCapabilityType.AppActivity, this.autActivityName);
+
+            this.driver = new AndroidDriver<AppiumWebElement>(appiumOptions: appiumOptions);
+
+            this.driver.StartActivity(appPackage: this.autPackageName, appActivity: this.autActivityName);
+        }
+
+        /// <summary>
+        /// An example test logging in to the TestProject native demo application on Android.
+        /// </summary>
+        [TestMethod]
+        public void ExampleTestUsingAndroidDriver()
+        {
+            this.driver.FindElement(By.Id("name")).SendKeys("John Smith");
+            this.driver.FindElement(By.Id("password")).SendKeys("12345");
+            this.driver.FindElement(By.Id("login")).Click();
+
+            Assert.IsTrue(this.driver.FindElement(By.Id("greetings")).Displayed);
+        }
+
+        /// <summary>
+        /// Closes the browser and ends the development session after each test.
+        /// </summary>
+        [TestCleanup]
+        public void CloseBrowser()
+        {
+            this.driver.Quit();
+        }
+    }
+}

--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -1,0 +1,190 @@
+﻿// <copyright file="AndroidDriver.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Drivers.Android
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using NLog;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Internal.Addons;
+    using TestProject.OpenSDK.Internal.CallStackAnalysis;
+    using TestProject.OpenSDK.Internal.Helpers;
+    using TestProject.OpenSDK.Internal.Helpers.CommandExecutors;
+    using TestProject.OpenSDK.Internal.Helpers.Threading;
+    using TestProject.OpenSDK.Internal.Reporting;
+    using TestProject.OpenSDK.Internal.Rest;
+
+    /// <summary>
+    /// Driver.
+    /// </summary>
+    /// <typeparam name="T">Type.</typeparam>
+    public class AndroidDriver<T> : OpenQA.Selenium.Appium.Android.AndroidDriver<T>, ITestProjectDriver
+        where T : IWebElement
+    {
+        /// <summary>
+        /// Flag that indicates whether or not the driver instance is running.
+        /// </summary>
+        public bool IsRunning { get; private set; }
+
+        private readonly DriverShutdownThread driverShutdownThread;
+
+        private readonly string sessionId;
+
+        private readonly CustomHttpCommandExecutor commandExecutor;
+
+        /// <summary>
+        /// Logger instance for this class.
+        /// </summary>
+        private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AndroidDriver{T}"/> class.
+        /// </summary>
+        /// <param name="remoteAddress">The base address for the Agent API (e.g. http://localhost:8585).</param>
+        /// <param name="token">The development token used to communicate with the Agent, see <a href="https://app.testproject.io/#/integrations/sdk">here</a> for more info.</param>
+        /// <param name="appiumOptions">See <see cref="AppiumOptions"/> for more details.</param>
+        /// <param name="projectName">The project name to report.</param>
+        /// <param name="jobName">The job name to report.</param>
+        /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        public AndroidDriver(
+            Uri remoteAddress = null,
+            string token = null,
+            AppiumOptions appiumOptions = null,
+            string projectName = null,
+            string jobName = null,
+            bool disableReports = false)
+            : base(
+                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.RemoteAddress,
+                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.Capabilities)
+        {
+            this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
+
+            // Set the session ID for the base driver object to the session ID returned by the Agent.
+            FieldInfo sessionIdField = typeof(RemoteWebDriver).GetField("sessionId", BindingFlags.Instance | BindingFlags.NonPublic);
+            sessionIdField.SetValue(this, new SessionId(this.sessionId));
+
+            // Create a new command executor for this driver session and set disable reporting flag
+            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
+
+            // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
+            // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).
+            if (AgentClient.GetInstance().IsInW3CMode())
+            {
+                var executorField = this.GetType().GetInheritedField("executor", BindingFlags.IgnoreCase | BindingFlags.NonPublic | BindingFlags.Instance);
+                var executor = (ICommandExecutor)executorField.GetValue(this);
+                var realExecutorField = executor.GetType().GetInheritedField("RealExecutor", BindingFlags.Instance | BindingFlags.NonPublic);
+                executor = (ICommandExecutor)realExecutorField.GetValue(executor);
+                var commandInfoRepository = executor.GetType().GetField("commandInfoRepository", BindingFlags.Instance | BindingFlags.NonPublic);
+                commandInfoRepository.SetValue(executor, typeof(AppiumCommand).CallPrivateStaticMethod("Merge", new object[] { new W3CWireProtocolCommandInfoRepository() }));
+            }
+
+            this.IsRunning = true;
+
+            // Add shutdown hook for gracefully shutting down the driver
+            this.driverShutdownThread = new DriverShutdownThread(this);
+
+            if (StackTraceHelper.Instance.TryDetectSpecFlow())
+            {
+                this.Report().DisableCommandReports(true);
+                this.Report().DisableAutoTestReports(true);
+                Logger.Info("SpecFlow detected, applying SpecFlow-specific reporting settings...");
+            }
+        }
+
+        /// <summary>
+        /// Enables access to the TestProject reporting actions from the driver object.
+        /// </summary>
+        /// <returns><see cref="Reporter"/> object exposing TestProject reporting methods.</returns>
+        public Reporter Report()
+        {
+            return new Reporter(this.commandExecutor.ReportingCommandExecutor);
+        }
+
+        /// <summary>
+        /// Enables access to the TestProject addon execution actions from the driver object.
+        /// </summary>
+        /// <returns><see cref="AddonHelper"/> object exposing TestProject action execution methods.</returns>
+        public AddonHelper Addons()
+        {
+            return new AddonHelper();
+        }
+
+        /// <summary>
+        /// Quits the driver and stops the session with the Agent, cleaning up after itself.
+        /// </summary>
+        public new void Quit()
+        {
+            if (this.IsRunning)
+            {
+                // Avoid performing the graceful shutdown more than once
+                this.driverShutdownThread.Dispose();
+
+                this.Stop();
+            }
+            else
+            {
+                Logger.Info("Driver is not running, skipping shutdown sequence");
+            }
+        }
+
+        /// <summary>
+        /// Sends any pending reports and closes the browser session.
+        /// </summary>
+        public void Stop()
+        {
+            // Report any stashed commands
+            this.commandExecutor.ReportingCommandExecutor.ClearStash();
+
+            this.IsRunning = false;
+
+            base.Quit();
+        }
+
+        /// <summary>
+        /// Overrides the base Execute() method by redirecting the WebDriver command to our own command executor.
+        /// </summary>
+        /// <param name="driverCommandToExecute">The WebDriver command to execute.</param>
+        /// <param name="parameters">Contains the parameters associated with this command.</param>
+        /// <returns>The response returned by the Agent upon requesting to execute this command.</returns>
+        protected override Response Execute(string driverCommandToExecute, Dictionary<string, object> parameters)
+        {
+            if (driverCommandToExecute.Equals(DriverCommand.NewSession))
+            {
+                var resp = new Response();
+                resp.Status = WebDriverResult.Success;
+                resp.SessionId = this.sessionId;
+                resp.Value = new Dictionary<string, object>();
+
+                return resp;
+            }
+
+            // The Agent does not understand the default way Selenium sends the driver command parameters for SendKeys
+            // This means we'll need to patch them so these commands can be executed.
+            if (!AgentClient.GetInstance().IsInW3CMode() && driverCommandToExecute.ShouldBePatched())
+            {
+                parameters = CommandHelper.UpdateSendKeysParameters(parameters);
+            }
+
+            Command command = new Command(new SessionId(this.sessionId), driverCommandToExecute, parameters);
+
+            return this.commandExecutor.Execute(command);
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Helpers/ExtensionMethods.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/ExtensionMethods.cs
@@ -17,6 +17,7 @@
 namespace TestProject.OpenSDK.Internal.Helpers
 {
     using System;
+    using System.Reflection;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
     using TestProject.OpenSDK.Internal.Rest;
@@ -73,6 +74,44 @@ namespace TestProject.OpenSDK.Internal.Helpers
         public static bool IsInW3CMode(this AgentClient agentClient)
         {
             return agentClient.AgentSession.Dialect.Equals("W3C");
+        }
+
+        /// <summary>
+        /// Retrieves field info for a field in a given type or any of its supertypes, using reflection.
+        /// </summary>
+        /// <param name="type">The type for which a field is to be found.</param>
+        /// <param name="name">The name of the field that should be found.</param>
+        /// <param name="flags">The binding flags to be applied when looking for the specified field.</param>
+        /// <returns>A <see cref="FieldInfo"/> object representing the field, or null if none was found.</returns>
+        public static FieldInfo GetInheritedField(this Type type, string name, BindingFlags flags)
+        {
+            FieldInfo fieldInfo = null;
+            while (type != null)
+            {
+                fieldInfo = type.GetField(name, flags);
+                if (fieldInfo != null)
+                {
+                    break;
+                }
+
+                type = type.BaseType;
+            }
+
+            return fieldInfo;
+        }
+
+        /// <summary>
+        /// Call private method.
+        /// </summary>
+        /// <param name="type">Object.</param>
+        /// <param name="methodName">Method name.</param>
+        /// <param name="args">Arguments.</param>
+        /// <returns>Return value.</returns>
+        public static object CallPrivateStaticMethod(this Type type, string methodName, params object[] args)
+        {
+            MethodInfo methodInfo = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+
+            return methodInfo == null ? null : methodInfo.Invoke(null, args);
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/AppiumSessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/AppiumSessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="AppiumSessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a mobile development session.
+    /// </summary>
+    public class AppiumSessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public Dictionary<string, object> Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/ChromeSessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/ChromeSessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="ChromeSessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using OpenQA.Selenium.Chrome;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a web development session.
+    /// </summary>
+    public class ChromeSessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public ChromeOptions Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/EdgeSessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/EdgeSessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="EdgeSessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using OpenQA.Selenium.Edge;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a web development session.
+    /// </summary>
+    public class EdgeSessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public EdgeOptions Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/FirefoxSessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/FirefoxSessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="FirefoxSessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using OpenQA.Selenium.Firefox;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a web development session.
+    /// </summary>
+    public class FirefoxSessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public FirefoxOptions Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/GenericSessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/GenericSessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="GenericSessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using TestProject.OpenSDK.Drivers.Generic;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a web development session.
+    /// </summary>
+    public class GenericSessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public GenericOptions Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/IESessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/IESessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="IESessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using OpenQA.Selenium.IE;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a web development session.
+    /// </summary>
+    public class IESessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public InternetExplorerOptions Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SafariSessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SafariSessionResponse.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="SafariSessionResponse.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses
+{
+    using OpenQA.Selenium.Safari;
+
+    /// <summary>
+    /// Payload object returned by the Agent when starting a web development session.
+    /// </summary>
+    public class SafariSessionResponse : SessionResponse
+    {
+        /// <summary>
+        /// Capabilities of the session that has been initialized by the Agent.
+        /// </summary>
+        public SafariOptions Capabilities { get; set; }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
@@ -16,12 +16,12 @@
 
 namespace TestProject.OpenSDK.Internal.Rest.Messages
 {
-    using OpenQA.Selenium.Chrome;
+    using OpenQA.Selenium;
 
     /// <summary>
     /// Payload object returned by the Agent when starting a development session.
     /// </summary>
-    public class SessionResponse
+    public abstract class SessionResponse
     {
         /// <summary>
         /// Port number that Agent is listening on for the SDK to connect.
@@ -42,11 +42,6 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         /// Dialect of the session that has been initialized by the Agent.
         /// </summary>
         public string Dialect { get; set; }
-
-        /// <summary>
-        /// Capabilities of the session that has been initialized by the Agent.
-        /// </summary>
-        public ChromeOptions Capabilities { get; set; }
 
         /// <summary>
         /// The current version of the Agent.


### PR DESCRIPTION
This PR adds support for Android native apps and Android web automation to the SDK.

I'm definitely open to suggestions on how to improve the logic that has been added to the `AgentClient` and what I've had to do with the `SessionResponse` objects, but a) this works and b) because every driver has their own specific `DriverOptions` implementation (DesiredCapabilities are obsolete, so I didn't want to use those), yet we can't deserialize into the DriverOptions class because it's abstract, plus AppiumOptions cannot be serialized into directly either, so we need a helper method for that, this is the only solution I could think of..