### PR TITLE
Fix/issue 105 no active driver exception handling

### DIFF
--- a/TestProject.OpenSDK.SpecFlowPlugin/TestProjectPlugin.cs
+++ b/TestProject.OpenSDK.SpecFlowPlugin/TestProjectPlugin.cs
@@ -18,7 +18,7 @@ using NLog;
 using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Plugins;
 using TechTalk.SpecFlow.UnitTestProvider;
-using TestProject.OpenSDK.Internal.Exceptions;
+using TestProject.OpenSDK.Exceptions;
 using TestProject.OpenSDK.Internal.Rest;
 using TestProject.OpenSDK.Internal.Rest.Messages;
 using TestProject.OpenSDK.SpecFlowPlugin;
@@ -107,10 +107,11 @@ namespace TestProject.OpenSDK.SpecFlowPlugin
             }
             else
             {
-                string message = $"No active Agent development session found. Please ensure that driver.Quit() is called in an [After] method, not in a step definition method.";
+                string message = $"No active Agent development session found. Please ensure that you have an instance of a TestProject OpenSDK driver running.\n" +
+                    $"More information on how to do that can be found in the README at https://github.com/testproject-io/csharp-opensdk";
 
                 Logger.Error(message);
-                throw new AgentConnectException(message);
+                throw new NoActiveDriverFoundException(message);
             }
         }
     }

--- a/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverChromeTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverChromeTest.cs
@@ -22,9 +22,8 @@ namespace TestProject.OpenSDK.Tests.Examples.Drivers
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Appium.Enums;
     using OpenQA.Selenium.Remote;
-    using OpenQA.Selenium.Support.UI;
     using TestProject.OpenSDK.Drivers.Android;
-    using TestProject.OpenSDK.Internal.Exceptions;
+    using TestProject.OpenSDK.Exceptions;
 
     /// <summary>
     /// This class contains examples of using the TestProject C# SDK with a Chrome browser on Android.

--- a/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Drivers/AndroidDriverTest.cs
@@ -23,7 +23,7 @@ namespace TestProject.OpenSDK.Tests.Examples.Drivers
     using OpenQA.Selenium.Appium.Enums;
     using OpenQA.Selenium.Remote;
     using TestProject.OpenSDK.Drivers.Android;
-    using TestProject.OpenSDK.Internal.Exceptions;
+    using TestProject.OpenSDK.Exceptions;
 
     /// <summary>
     /// This class contains examples of using the TestProject C# SDK with a native Android app.

--- a/TestProject.OpenSDK/Exceptions/AddonNotInstalledException.cs
+++ b/TestProject.OpenSDK/Exceptions/AddonNotInstalledException.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Internal.Exceptions
+namespace TestProject.OpenSDK.Exceptions
 {
     using System;
 

--- a/TestProject.OpenSDK/Exceptions/AgentConnectException.cs
+++ b/TestProject.OpenSDK/Exceptions/AgentConnectException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MissingBrowserException.cs" company="TestProject">
+﻿// <copyright file="AgentConnectException.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +14,20 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Internal.Exceptions
+namespace TestProject.OpenSDK.Exceptions
 {
     using System;
 
     /// <summary>
-    /// Exception object thrown when the requested browser is not found on the machine running the tests.
+    /// Exception object thrown when the SDK version used is not supported by the Agent.
     /// </summary>
-    public class MissingBrowserException : Exception
+    public class AgentConnectException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MissingBrowserException"/> class with the provided message.
+        /// Initializes a new instance of the <see cref="AgentConnectException"/> class with the provided message.
         /// </summary>
         /// <param name="message">Exception message to be set.</param>
-        public MissingBrowserException(string message)
+        public AgentConnectException(string message)
             : base(message)
         {
         }

--- a/TestProject.OpenSDK/Exceptions/InvalidTokenException.cs
+++ b/TestProject.OpenSDK/Exceptions/InvalidTokenException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SdkException.cs" company="TestProject">
+﻿// <copyright file="InvalidTokenException.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +14,20 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Internal.Exceptions
+namespace TestProject.OpenSDK.Exceptions
 {
     using System;
 
     /// <summary>
-    /// Exception object thrown whenever something unexpected happens in the SDK code.
+    /// Exception object thrown when token provided is rejected by the Agent.
     /// </summary>
-    public class SdkException : Exception
+    public class InvalidTokenException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SdkException"/> class with the provided message.
+        /// Initializes a new instance of the <see cref="InvalidTokenException"/> class with the provided message.
         /// </summary>
         /// <param name="message">Exception message to be set.</param>
-        public SdkException(string message)
+        public InvalidTokenException(string message)
             : base(message)
         {
         }

--- a/TestProject.OpenSDK/Exceptions/MissingBrowserException.cs
+++ b/TestProject.OpenSDK/Exceptions/MissingBrowserException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AgentConnectException.cs" company="TestProject">
+﻿// <copyright file="MissingBrowserException.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +14,20 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Internal.Exceptions
+namespace TestProject.OpenSDK.Exceptions
 {
     using System;
 
     /// <summary>
-    /// Exception object thrown when the SDK version used is not supported by the Agent.
+    /// Exception object thrown when the requested browser is not found on the machine running the tests.
     /// </summary>
-    public class AgentConnectException : Exception
+    public class MissingBrowserException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AgentConnectException"/> class with the provided message.
+        /// Initializes a new instance of the <see cref="MissingBrowserException"/> class with the provided message.
         /// </summary>
         /// <param name="message">Exception message to be set.</param>
-        public AgentConnectException(string message)
+        public MissingBrowserException(string message)
             : base(message)
         {
         }

--- a/TestProject.OpenSDK/Exceptions/NoActiveDriverFoundException.cs
+++ b/TestProject.OpenSDK/Exceptions/NoActiveDriverFoundException.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="NoActiveDriverFoundException.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// Exception object thrown when the SDK version used is not supported by the Agent.
+    /// </summary>
+    public class NoActiveDriverFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NoActiveDriverFoundException"/> class with the provided message.
+        /// </summary>
+        /// <param name="message">Exception message to be set.</param>
+        public NoActiveDriverFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/TestProject.OpenSDK/Exceptions/ObsoleteVersionException.cs
+++ b/TestProject.OpenSDK/Exceptions/ObsoleteVersionException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InvalidTokenException.cs" company="TestProject">
+﻿// <copyright file="ObsoleteVersionException.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +14,20 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Internal.Exceptions
+namespace TestProject.OpenSDK.Exceptions
 {
     using System;
 
     /// <summary>
-    /// Exception object thrown when token provided is rejected by the Agent.
+    /// Exception object thrown when the SDK version used is not supported by the Agent.
     /// </summary>
-    public class InvalidTokenException : Exception
+    public class ObsoleteVersionException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidTokenException"/> class with the provided message.
+        /// Initializes a new instance of the <see cref="ObsoleteVersionException"/> class with the provided message.
         /// </summary>
         /// <param name="message">Exception message to be set.</param>
-        public InvalidTokenException(string message)
+        public ObsoleteVersionException(string message)
             : base(message)
         {
         }

--- a/TestProject.OpenSDK/Exceptions/SdkException.cs
+++ b/TestProject.OpenSDK/Exceptions/SdkException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ObsoleteVersionException.cs" company="TestProject">
+﻿// <copyright file="SdkException.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,20 +14,20 @@
 // limitations under the License.
 // </copyright>
 
-namespace TestProject.OpenSDK.Internal.Exceptions
+namespace TestProject.OpenSDK.Exceptions
 {
     using System;
 
     /// <summary>
-    /// Exception object thrown when the SDK version used is not supported by the Agent.
+    /// Exception object thrown whenever something unexpected happens in the SDK code.
     /// </summary>
-    public class ObsoleteVersionException : Exception
+    public class SdkException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ObsoleteVersionException"/> class with the provided message.
+        /// Initializes a new instance of the <see cref="SdkException"/> class with the provided message.
         /// </summary>
         /// <param name="message">Exception message to be set.</param>
-        public ObsoleteVersionException(string message)
+        public SdkException(string message)
             : base(message)
         {
         }

--- a/TestProject.OpenSDK/Internal/Addons/AddonHelper.cs
+++ b/TestProject.OpenSDK/Internal/Addons/AddonHelper.cs
@@ -21,7 +21,7 @@ namespace TestProject.OpenSDK.Internal.Addons
     using Newtonsoft.Json;
     using NLog;
     using OpenQA.Selenium;
-    using TestProject.OpenSDK.Internal.Exceptions;
+    using TestProject.OpenSDK.Exceptions;
     using TestProject.OpenSDK.Internal.Helpers;
     using TestProject.OpenSDK.Internal.Rest;
     using TestProject.OpenSDK.Internal.Rest.Messages;

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
@@ -31,7 +31,6 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
     {
         private const string KeepSessionEnvironmentVariable = "TP_KEEP_DRIVER_SESSION";
 
-
         private static readonly bool KeepDriverSession;
 
         static CustomHttpCommandExecutor()

--- a/TestProject.OpenSDK/Internal/Helpers/DriverOptions/DriverOptionsHelper.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/DriverOptions/DriverOptionsHelper.cs
@@ -21,7 +21,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.DriverOptions
     using OpenQA.Selenium.Firefox;
     using OpenQA.Selenium.IE;
     using OpenQA.Selenium.Safari;
-    using TestProject.OpenSDK.Internal.Exceptions;
+    using TestProject.OpenSDK.Exceptions;
 
     /// <summary>
     /// Provides utility methods to patch <see cref="DriverOptions"/> objects to make them suitable to start a session with the Agent.

--- a/TestProject.OpenSDK/Internal/Helpers/LocatorHelper.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/LocatorHelper.cs
@@ -18,7 +18,7 @@ namespace TestProject.OpenSDK.Internal.Helpers
 {
     using System.Collections.Generic;
     using OpenQA.Selenium;
-    using TestProject.OpenSDK.Internal.Exceptions;
+    using TestProject.OpenSDK.Exceptions;
 
     /// <summary>
     /// Class containing extension methods for Selenium <see cref="By"/> locators.

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -31,9 +31,9 @@ namespace TestProject.OpenSDK.Internal.Rest
     using OpenQA.Selenium.Safari;
     using RestSharp;
     using TestProject.OpenSDK.Drivers.Generic;
+    using TestProject.OpenSDK.Exceptions;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
-    using TestProject.OpenSDK.Internal.Exceptions;
     using TestProject.OpenSDK.Internal.Helpers;
     using TestProject.OpenSDK.Internal.Rest.Messages;
     using TestProject.OpenSDK.Internal.Rest.Messages.SessionResponses;

--- a/TestProject.OpenSDK/Internal/Tcp/SocketManager.cs
+++ b/TestProject.OpenSDK/Internal/Tcp/SocketManager.cs
@@ -19,7 +19,7 @@ namespace TestProject.OpenSDK.Internal.Tcp
     using System;
     using System.Net.Sockets;
     using NLog;
-    using TestProject.OpenSDK.Internal.Exceptions;
+    using TestProject.OpenSDK.Exceptions;
     using TestProject.OpenSDK.Internal.Helpers.Threading;
 
     /// <summary>


### PR DESCRIPTION
This PR:
- Moves all exception to a namespace that doesn't include `Internal` as they are visible to the user (external behaviour)
- Adds a new exception that is used when the SpecFlow plugin can't report steps due to no active driver session found