### PR TITLE
Fix/issue 109 no agent connection

### DIFF
--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -335,6 +335,14 @@ namespace TestProject.OpenSDK.Internal.Rest
 
             IRestResponse startSessionResponse = this.client.Execute(startSessionRequest);
 
+            if (startSessionResponse.ErrorException != null)
+            {
+                string errorMessage = $"An error occurred connecting to the Agent. Is your Agent running at {this.remoteAddress}?";
+
+                Logger.Error(errorMessage);
+                throw new AgentConnectException(errorMessage);
+            }
+
             if ((int)startSessionResponse.StatusCode >= 400)
             {
                 this.HandleSessionStartFailure(startSessionResponse);


### PR DESCRIPTION
This PR improves exception handling in cases where the SDK cannot connect to the Agent (for example when the Agent isn't running, or when the specified Agent address is invalid).