### PR TITLE
Fix possible NullPointerException for drivers created in test class c…

### DIFF
--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/SpecFlowAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/SpecFlowAnalyzer.cs
@@ -30,7 +30,14 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         /// </summary>
         /// <param name="method">The method to be analyzed.</param>
         /// <returns>True if the method is running inside a SpecFlow scenario, false otherwise.</returns>
-        public bool IsSpecFlow(MethodBase method) =>
-            method.DeclaringType.Namespace.StartsWith(SpecFlowNamespace);
+        public bool IsSpecFlow(MethodBase method)
+        {
+            if (method.DeclaringType.Namespace != null)
+            {
+                return method.DeclaringType.Namespace.StartsWith(SpecFlowNamespace);
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue that occurs when people are trying to create driver instances in test class constructors instead of in test or setup methods. This caused a `NullReferenceException` because elements in the stack trace might have a namespace value of `null` in that case, and we're looking for the right namespace when trying to detect whether someone is using SpecFlow.