### PR TITLE
Fix/111 specflow feature name as job

### DIFF
--- a/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowExample.feature
+++ b/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowExample.feature
@@ -1,4 +1,4 @@
-﻿Feature: SpecFlowExample
+﻿Feature: A sample SpecFlow feature
 	In order to see beautiful SpecFlow reports on TestProject Cloud
 	As a TestProject user
 	I want to run SpecFlow scenarios supported by the SDK

--- a/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowExample.feature.cs
+++ b/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowExample.feature.cs
@@ -20,8 +20,8 @@ namespace TestProject.OpenSDK.SpecFlowExamples.Features
     [System.CodeDom.Compiler.GeneratedCodeAttribute("TechTalk.SpecFlow", "3.5.0.0")]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
-    [NUnit.Framework.DescriptionAttribute("SpecFlowExample")]
-    public partial class SpecFlowExampleFeature
+    [NUnit.Framework.DescriptionAttribute("A sample SpecFlow feature")]
+    public partial class ASampleSpecFlowFeatureFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
@@ -35,7 +35,7 @@ namespace TestProject.OpenSDK.SpecFlowExamples.Features
         public virtual void FeatureSetup()
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
-            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "SpecFlowExample", "\tIn order to see beautiful SpecFlow reports on TestProject Cloud\r\n\tAs a TestProje" +
+            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "A sample SpecFlow feature", "\tIn order to see beautiful SpecFlow reports on TestProject Cloud\r\n\tAs a TestProje" +
                     "ct user\r\n\tI want to run SpecFlow scenarios supported by the SDK", ProgrammingLanguage.CSharp, ((string[])(null)));
             testRunner.OnFeatureStart(featureInfo);
         }

--- a/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowScenarioOutlineExample.feature
+++ b/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowScenarioOutlineExample.feature
@@ -1,4 +1,4 @@
-﻿Feature: SpecFlowScenarioOutlineExample
+﻿Feature: SpecFlow example containing a scenario outline
 	In order to see beautiful SpecFlow reports on TestProject Cloud
 	As a TestProject user
 	I want to run SpecFlow scenarios supported by the SDK

--- a/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowScenarioOutlineExample.feature.cs
+++ b/TestProject.OpenSDK.SpecFlowExamples/Features/SpecFlowScenarioOutlineExample.feature.cs
@@ -20,8 +20,8 @@ namespace TestProject.OpenSDK.SpecFlowExamples.Features
     [System.CodeDom.Compiler.GeneratedCodeAttribute("TechTalk.SpecFlow", "3.5.0.0")]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [NUnit.Framework.TestFixtureAttribute()]
-    [NUnit.Framework.DescriptionAttribute("SpecFlowScenarioOutlineExample")]
-    public partial class SpecFlowScenarioOutlineExampleFeature
+    [NUnit.Framework.DescriptionAttribute("SpecFlow example containing a scenario outline")]
+    public partial class SpecFlowExampleContainingAScenarioOutlineFeature
     {
         
         private TechTalk.SpecFlow.ITestRunner testRunner;
@@ -35,7 +35,7 @@ namespace TestProject.OpenSDK.SpecFlowExamples.Features
         public virtual void FeatureSetup()
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
-            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "SpecFlowScenarioOutlineExample", "\tIn order to see beautiful SpecFlow reports on TestProject Cloud\r\n\tAs a TestProje" +
+            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Features", "SpecFlow example containing a scenario outline", "\tIn order to see beautiful SpecFlow reports on TestProject Cloud\r\n\tAs a TestProje" +
                     "ct user\r\n\tI want to run SpecFlow scenarios supported by the SDK", ProgrammingLanguage.CSharp, ((string[])(null)));
             testRunner.OnFeatureStart(featureInfo);
         }

--- a/TestProject.OpenSDK.SpecFlowExamples/TestProject.OpenSDK.SpecFlowExamples.csproj
+++ b/TestProject.OpenSDK.SpecFlowExamples/TestProject.OpenSDK.SpecFlowExamples.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.5.14" />

--- a/TestProject.OpenSDK.Tests/TestProject.OpenSDK.Tests.csproj
+++ b/TestProject.OpenSDK.Tests/TestProject.OpenSDK.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/NUnitStackTraceHelperWithClassDescriptionTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/NUnitStackTraceHelperWithClassDescriptionTest.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="NUnitStackTraceHelperWithClassDescriptionTest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
+{
+    using NUnit.Framework;
+    using TestProject.OpenSDK.Internal.CallStackAnalysis;
+
+    /// <summary>
+    /// Class containing unit tests for the <see cref="StackTraceHelper"/> class using NUnit.
+    /// </summary>
+    [TestFixture]
+    [Description("This is a class-level description")]
+    public class NUnitStackTraceHelperWithClassDescriptionTest
+    {
+        /// <summary>
+        /// Inferring the job name for a class with a [Description] attribute should yield the description value.
+        /// </summary>
+        [Test]
+        public void GetInferredJobName_CheckResult_ShouldEqualCurrentTestClass()
+        {
+            string jobName = StackTraceHelper.Instance.GetInferredJobName();
+
+            Assert.AreEqual("This is a class-level description", jobName);
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/IMethodAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/IMethodAnalyzer.cs
@@ -43,5 +43,12 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         /// <param name="method">The method to be analyzed.</param>
         /// <returns>Test name, or null if method not supported by this analyzer.</returns>
         string GetTestName(MethodBase method);
+
+        /// <summary>
+        /// Gets the value of the description attribute for the test class.
+        /// </summary>
+        /// <param name="method">The method to be analyzed.</param>
+        /// <returns>The test class description value, or null if none is present or test class descriptions are not supported.</returns>
+        string GetTestClassDescription(MethodBase method);
     }
 }

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/MSTestAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/MSTestAnalyzer.cs
@@ -65,5 +65,12 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
                 && a.GetType().Namespace.Equals(MSTestFrameworkNamespace));
             return attribute?.GetType().GetProperty(TestNameProperty)?.GetValue(attribute)?.ToString();
         }
+
+        /// <inheritdoc cref="IMethodAnalyzer"/>
+        public string GetTestClassDescription(MethodBase method)
+        {
+            // MSTest does not support description attributes at the test class level.
+            return null;
+        }
     }
 }

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/NUnitAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/NUnitAnalyzer.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
 {
     using System.Linq;
     using System.Reflection;
+    using NUnit.Framework;
 
     /// <summary>
     /// Defines methods that are used to determine whether or not a method belongs to NUnit.
@@ -26,8 +27,9 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
     {
         private const string TestAttribute = "TestAttribute";
         private const string SetUpAttribute = "SetUpAttribute";
+        private const string TestClassDescriptionAttribute = "DescriptionAttribute";
         private const string NUnitFrameworkNamespace = "NUnit.Framework";
-        private const string TestNameProperty = "Description";
+        private const string DescriptionProperty = "Description";
 
         /// <summary>
         /// Determines whether or not the class containing the method that is run belongs to NUnit.
@@ -60,7 +62,18 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
             var attribute = method.GetCustomAttributes(true)
                 .FirstOrDefault(a => a.GetType().Name.Equals(TestAttribute)
                                      && a.GetType().Namespace.Equals(NUnitFrameworkNamespace));
-            return attribute?.GetType().GetProperty(TestNameProperty)?.GetValue(attribute)?.ToString();
+            return attribute?.GetType().GetProperty(DescriptionProperty)?.GetValue(attribute)?.ToString();
+        }
+
+        /// <inheritdoc cref="IMethodAnalyzer"/>
+        public string GetTestClassDescription(MethodBase method)
+        {
+            // Test class has a Description property set this way: [TestFixture(Description = "name")]
+            DescriptionAttribute attribute = method.DeclaringType.GetCustomAttributes<DescriptionAttribute>(true)
+                .FirstOrDefault(a => a.GetType().Name.Equals(TestClassDescriptionAttribute)
+                                     && a.GetType().Namespace.Equals(NUnitFrameworkNamespace));
+
+            return attribute?.Properties.Get(DescriptionProperty).ToString();
         }
     }
 }

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
@@ -46,7 +46,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         /// <returns>The inferred test method name.</returns>
         public string GetInferredTestName()
         {
-            var testMethod = this.TryDetectTestMethod();
+            MethodBase testMethod = this.TryDetectTestMethod();
             return this.analyzers.Select(a => a.GetTestName(testMethod)).FirstOrDefault(n => !string.IsNullOrEmpty(n))
                 ?? testMethod.Name;
         }
@@ -59,6 +59,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         public string GetInferredProjectName()
         {
             MethodBase method = this.TryDetectSetupMethod() ?? this.TryDetectTestMethod();
+
             return method.DeclaringType.Namespace.Split('.').Last();
         }
 
@@ -68,8 +69,10 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         /// <returns>The inferred job name.</returns>
         public string GetInferredJobName()
         {
-            MethodBase method = this.TryDetectSetupMethod() ?? this.TryDetectTestMethod();
-            return method.DeclaringType.Name;
+            MethodBase testMethod = this.TryDetectSetupMethod() ?? this.TryDetectTestMethod();
+
+            return this.analyzers.Select(a => a.GetTestClassDescription(testMethod)).FirstOrDefault(n => !string.IsNullOrEmpty(n))
+                ?? testMethod.DeclaringType.Name;
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/XUnitAnalyzer.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/XUnitAnalyzer.cs
@@ -59,5 +59,12 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
 
             return attribute?.GetType().GetProperty(TestNameProperty)?.GetValue(attribute)?.ToString();
         }
+
+        /// <inheritdoc cref="IMethodAnalyzer"/>
+        public string GetTestClassDescription(MethodBase method)
+        {
+            // xUnit does not support description attributes at the test class level.
+            return null;
+        }
     }
 }

--- a/TestProject.OpenSDK/TestProject.OpenSDK.csproj
+++ b/TestProject.OpenSDK/TestProject.OpenSDK.csproj
@@ -24,6 +24,7 @@ From now on, you can effortlessly execute Selenium and Appium native tests using
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="RestSharp" Version="106.11.7" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
This PR adds logic to infer the job name using the value of the class-level `Description` attribute for NUnit. As a result, when using SpecFlow with NUnit, the job name will automatically be set to the feature title as set in the .feature file, but it works without SpecFlow, too (see the added unit test).

Once other unit testing frameworks start supporting this too, the logic can simply be extended, but as far as I can see NUnit is the only unit testing framework that supports this for now.