### PR TITLE
Improve error handling when trying to start a generic driver session …

### DIFF
--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -518,6 +518,14 @@ namespace TestProject.OpenSDK.Internal.Rest
 
             IRestResponse getAgentStatusResponse = this.client.Execute(getAgentStatusRequest);
 
+            if (getAgentStatusResponse.ErrorException != null)
+            {
+                string errorMessage = $"An error occurred connecting to the Agent. Is your Agent running at {this.remoteAddress}?";
+
+                Logger.Error(errorMessage);
+                throw new AgentConnectException(errorMessage);
+            }
+
             if ((int)getAgentStatusResponse.StatusCode >= 400)
             {
                 throw new AgentConnectException($"Failed to get Agent status: {getAgentStatusResponse.ErrorMessage}");


### PR DESCRIPTION
This PR improves error handling in the case where you try to start a generic driver session when the Agent is not running. Previously, it threw a `NullReferenceException` when trying to determine the Agent version (to see if generic drivers were supported), now it throws an `AgentConnectException` similar to what happens with the other drivers.