### PR TITLE
Fix/improve nosuchelement exception handling

### DIFF
--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -22,6 +22,7 @@ namespace TestProject.OpenSDK.Drivers
     using NLog;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Exceptions;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers;
@@ -154,6 +155,24 @@ namespace TestProject.OpenSDK.Drivers
             this.IsRunning = false;
 
             base.Quit();
+        }
+
+        /// <summary>
+        /// test.
+        /// </summary>
+        /// <param name="by">By.</param>
+        /// <returns>Element.</returns>
+        public new IWebElement FindElement(By by)
+        {
+            try
+            {
+                return base.FindElement(by);
+            }
+            catch (ArgumentException)
+            {
+                Logger.Error($"Could not find element located by {by.ToString()}");
+                throw new ElementNotFoundException($"Could not find element located by {by.ToString()}");
+            }
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Exceptions/ElementNotFoundException.cs
+++ b/TestProject.OpenSDK/Exceptions/ElementNotFoundException.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ElementNotFoundException.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Exceptions
+{
+    using System;
+    using OpenQA.Selenium;
+    using TestProject.OpenSDK.Drivers;
+
+    /// <summary>
+    /// Exception object thrown when an <see cref="IWebElement"/> could not be found in the <see cref="BaseDriver"/>.
+    /// </summary>
+    public class ElementNotFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElementNotFoundException"/> class with the provided message.
+        /// </summary>
+        /// <param name="message">Exception message to be set.</param>
+        public ElementNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR improves error handling when a requested element cannot be found. Before, the `System.ArgumentException` thrown by the Selenium `RemoteWebDriver` was visible to the OpenSDK user. I've overridden the `FindElement` method so that it catches that exception and throws a new, custom `ElementNotFoundException` with a much more expressive message.