### PR TITLE
Rename MissingBrowserException to MissingBrowserOrDeviceException

### DIFF
--- a/TestProject.OpenSDK/Exceptions/MissingBrowserOrDeviceException.cs
+++ b/TestProject.OpenSDK/Exceptions/MissingBrowserOrDeviceException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MissingBrowserException.cs" company="TestProject">
+﻿// <copyright file="MissingBrowserOrDeviceException.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,15 +19,15 @@ namespace TestProject.OpenSDK.Exceptions
     using System;
 
     /// <summary>
-    /// Exception object thrown when the requested browser is not found on the machine running the tests.
+    /// Exception object thrown when the requested browser or mobile device is not found on the machine running the tests.
     /// </summary>
-    public class MissingBrowserException : Exception
+    public class MissingBrowserOrDeviceException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MissingBrowserException"/> class with the provided message.
+        /// Initializes a new instance of the <see cref="MissingBrowserOrDeviceException"/> class with the provided message.
         /// </summary>
         /// <param name="message">Exception message to be set.</param>
-        public MissingBrowserException(string message)
+        public MissingBrowserOrDeviceException(string message)
             : base(message)
         {
         }

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -497,8 +497,8 @@ namespace TestProject.OpenSDK.Internal.Rest
                         " and set it in the TP_DEV_TOKEN environment variable");
                     throw new InvalidTokenException(responseMessage);
                 case 404:
-                    Logger.Error("Failed to initialize a session with the Agent - requested browser not found on this system");
-                    throw new MissingBrowserException(responseMessage);
+                    Logger.Error("Failed to initialize a session with the Agent - requested browser or mobile device not found on this system");
+                    throw new MissingBrowserOrDeviceException(responseMessage);
                 case 406:
                     Logger.Error("Failed to initialize a session with the Agent - obsolete SDK version");
                     throw new ObsoleteVersionException(responseMessage);


### PR DESCRIPTION
This PR renames the `MissingBrowserException` to `MissingBrowserOrDeviceException` as it will be thrown as well when a requested mobile device is not found, not just when a (desktop) browser is not installed on the local system.