### PR TITLE
Implement ITouchScreen interface for mobile drivers

### DIFF
--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -35,13 +35,18 @@ namespace TestProject.OpenSDK.Drivers.Android
     /// Driver.
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
-    public class AndroidDriver<T> : OpenQA.Selenium.Appium.Android.AndroidDriver<T>, ITestProjectDriver
+    public class AndroidDriver<T> : OpenQA.Selenium.Appium.Android.AndroidDriver<T>, ITestProjectDriver, IHasTouchScreen
         where T : IWebElement
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
         /// </summary>
         public bool IsRunning { get; private set; }
+
+        /// <summary>
+        /// Allows execution of basic touch screen operations.
+        /// </summary>
+        public ITouchScreen TouchScreen { get; }
 
         private readonly DriverShutdownThread driverShutdownThread;
 

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -35,13 +35,18 @@ namespace TestProject.OpenSDK.Drivers.IOS
     /// Driver.
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
-    public class IOSDriver<T> : OpenQA.Selenium.Appium.iOS.IOSDriver<T>, ITestProjectDriver
+    public class IOSDriver<T> : OpenQA.Selenium.Appium.iOS.IOSDriver<T>, ITestProjectDriver, IHasTouchScreen
         where T : IWebElement
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
         /// </summary>
         public bool IsRunning { get; private set; }
+
+        /// <summary>
+        /// Allows execution of basic touch screen operations.
+        /// </summary>
+        public ITouchScreen TouchScreen { get; }
 
         private readonly DriverShutdownThread driverShutdownThread;
 


### PR DESCRIPTION
This PR resolves an issue where `TouchActions` could not be performed because the SDK drivers did not implement a required interface.