### PR TITLE
Feature/report failing driver commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,20 @@ driver.Report().DisableAutoTestReports(true);
 
 ### Disable driver command reports
 
-This will disable driver _command_ reporting. The resulting report will have no steps, unless reported manually using `driver.Report().Step()`:
+This will disable driver _command_ reporting. There are three options here:
+
+* `DisableCommandReports(DriverCommands.All)` disables the reporting of all driver commands.
+* `DisableCommandReports(DriverCommands.Passing)` disables the reporting of passing driver commands. Failing driver commands will still be reported as manual steps, including a screenshot.
+* `DisableCommandReports(DriverCommands.None)` reports all driver commands as normal.
+
+For example, the following:
 
 ```csharp
 ChromeDriver driver = new ChromeDriver(chromeOptions: new ChromeOptions());
-driver.Report().DisableCommandReports(true);
+driver.Report().DisableCommandReports(DriverCommands.All);
 ```
+
+will result in a report with no steps, unless they are reported manually using `driver.Report().Step()`.
 
 ### Disable command redaction
 

--- a/TestProject.OpenSDK.Tests/Examples/Reports/ManualReportingTest.cs
+++ b/TestProject.OpenSDK.Tests/Examples/Reports/ManualReportingTest.cs
@@ -19,6 +19,7 @@ namespace TestProject.OpenSDK.Tests.Examples.Reports
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using OpenQA.Selenium;
     using TestProject.OpenSDK.Drivers.Web;
+    using TestProject.OpenSDK.Enums;
 
     /// <summary>
     /// This class contains examples of using the TestProject C# SDK with manual reporting steps.
@@ -40,6 +41,13 @@ namespace TestProject.OpenSDK.Tests.Examples.Reports
             this.driver = new ChromeDriver(
                 projectName: "Examples",
                 jobName: "Manual reporting examples");
+
+            // Disabling the automatic reporting of tests, so only manually reported tests will show up in the report.
+            this.driver.Report().DisableAutoTestReports(true);
+
+            // Disabling the reporting of all driver commands (both passed and failed ones),
+            // so only manually reported steps will show up in the report.
+            this.driver.Report().DisableCommandReports(DriverCommandsFilter.All);
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -22,6 +22,7 @@ namespace TestProject.OpenSDK.Drivers.Android
     using NLog;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers;
@@ -106,7 +107,7 @@ namespace TestProject.OpenSDK.Drivers.Android
 
             if (StackTraceHelper.Instance.TryDetectSpecFlow())
             {
-                this.Report().DisableCommandReports(true);
+                this.Report().DisableCommandReports(DriverCommandsFilter.All);
                 this.Report().DisableAutoTestReports(true);
                 Logger.Info("SpecFlow detected, applying SpecFlow-specific reporting settings...");
             }

--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -22,6 +22,7 @@ namespace TestProject.OpenSDK.Drivers
     using NLog;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers;
@@ -102,7 +103,7 @@ namespace TestProject.OpenSDK.Drivers
             if (StackTraceHelper.Instance.TryDetectSpecFlow())
             {
                 Logger.Info("SpecFlow detected, applying SpecFlow-specific reporting settings...");
-                this.Report().DisableCommandReports(true);
+                this.Report().DisableCommandReports(DriverCommandsFilter.All);
                 this.Report().DisableAutoTestReports(true);
             }
         }

--- a/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Generic
 {
     using System;
     using NLog;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers.CommandExecutors;
     using TestProject.OpenSDK.Internal.Reporting;
@@ -72,7 +73,7 @@ namespace TestProject.OpenSDK.Drivers.Generic
             if (StackTraceHelper.Instance.TryDetectSpecFlow())
             {
                 Logger.Info("SpecFlow detected, applying SpecFlow-specific reporting settings...");
-                this.Report().DisableCommandReports(true);
+                this.Report().DisableCommandReports(DriverCommandsFilter.All);
                 this.Report().DisableAutoTestReports(true);
             }
         }

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -22,6 +22,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
     using NLog;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Remote;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
     using TestProject.OpenSDK.Internal.Helpers;
@@ -106,7 +107,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
 
             if (StackTraceHelper.Instance.TryDetectSpecFlow())
             {
-                this.Report().DisableCommandReports(true);
+                this.Report().DisableCommandReports(DriverCommandsFilter.All);
                 this.Report().DisableAutoTestReports(true);
                 Logger.Info("SpecFlow detected, applying SpecFlow-specific reporting settings...");
             }

--- a/TestProject.OpenSDK/Enums/DriverCommandsFilter.cs
+++ b/TestProject.OpenSDK/Enums/DriverCommandsFilter.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="DriverCommandsFilter.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Enums
+{
+    /// <summary>
+    /// Enumeration of options for driver command reporting.
+    /// </summary>
+    public enum DriverCommandsFilter
+    {
+        /// <summary>
+        /// Always report driver commands.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Only report failing driver commands.
+        /// </summary>
+        Passing,
+
+        /// <summary>
+        /// Never report driver commands.
+        /// </summary>
+        All,
+    }
+}

--- a/TestProject.OpenSDK/Internal/Reporting/Reporter.cs
+++ b/TestProject.OpenSDK/Internal/Reporting/Reporter.cs
@@ -16,7 +16,9 @@
 
 namespace TestProject.OpenSDK.Internal.Reporting
 {
+    using System;
     using NLog;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.CommandExecutors;
     using TestProject.OpenSDK.Internal.Rest;
     using TestProject.OpenSDK.Internal.Rest.Messages;
@@ -110,9 +112,19 @@ namespace TestProject.OpenSDK.Internal.Reporting
         /// Enables / disables automatic driver command reporting.
         /// </summary>
         /// <param name="disable">True to disable automatic driver command reporting, false to enable.</param>
+        [Obsolete("Please use DisableCommandReports(ReportDriverCommand) instead.")]
         public void DisableCommandReports(bool disable)
         {
-            this.reportingCommandExecutor.CommandReportsDisabled = disable;
+            this.reportingCommandExecutor.CommandReportsDisabled = disable ? DriverCommandsFilter.All : DriverCommandsFilter.None;
+        }
+
+        /// <summary>
+        /// Enables / disables automatic driver command reporting.
+        /// </summary>
+        /// <param name="driverCommandsToSkip">Preferred settings for reporting driver commands.</param>
+        public void DisableCommandReports(DriverCommandsFilter driverCommandsToSkip)
+        {
+            this.reportingCommandExecutor.CommandReportsDisabled = driverCommandsToSkip;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR offers more customization around driver command reporting, letting the user choose between reporting all driver commands, none, or only the failing ones.