### PR TITLE
Feature/144 add methods to itestprojectdriver interface

### DIFF
--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -20,7 +20,6 @@ namespace TestProject.OpenSDK.Drivers.Android
     using System.Collections.Generic;
     using System.Reflection;
     using NLog;
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Remote;
     using TestProject.OpenSDK.Internal.Addons;
@@ -35,8 +34,8 @@ namespace TestProject.OpenSDK.Drivers.Android
     /// Driver.
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
-    public class AndroidDriver<T> : OpenQA.Selenium.Appium.Android.AndroidDriver<T>, ITestProjectDriver, IHasTouchScreen
-        where T : IWebElement
+    public class AndroidDriver<T> : OpenQA.Selenium.Appium.Android.AndroidDriver<T>, IWebDriver, OpenQA.Selenium.IHasTouchScreen
+        where T : OpenQA.Selenium.IWebElement
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
@@ -46,7 +45,7 @@ namespace TestProject.OpenSDK.Drivers.Android
         /// <summary>
         /// Allows execution of basic touch screen operations.
         /// </summary>
-        public ITouchScreen TouchScreen { get; }
+        public OpenQA.Selenium.ITouchScreen TouchScreen { get; }
 
         private readonly DriverShutdownThread driverShutdownThread;
 
@@ -173,7 +172,7 @@ namespace TestProject.OpenSDK.Drivers.Android
             if (driverCommandToExecute.Equals(DriverCommand.NewSession))
             {
                 var resp = new Response();
-                resp.Status = WebDriverResult.Success;
+                resp.Status = OpenQA.Selenium.WebDriverResult.Success;
                 resp.SessionId = this.sessionId;
                 resp.Value = new Dictionary<string, object>();
 

--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -34,7 +34,7 @@ namespace TestProject.OpenSDK.Drivers
     /// Extension of <see cref="OpenQA.Selenium.Chrome.ChromeDriver">ChromeDriver</see> for use with TestProject.
     /// Instead of initializing a new session, it starts it in the TestProject Agent and then reconnects to it.
     /// </summary>
-    public class BaseDriver : RemoteWebDriver, ITestProjectDriver
+    public class BaseDriver : RemoteWebDriver, IWebDriver
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.

--- a/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
@@ -26,7 +26,7 @@ namespace TestProject.OpenSDK.Drivers.Generic
     /// <summary>
     /// Generic driver that can be used to execute non-UI automation and upload the results to TestProject.
     /// </summary>
-    public class GenericDriver : ITestProjectDriver
+    public class GenericDriver
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -20,7 +20,6 @@ namespace TestProject.OpenSDK.Drivers.IOS
     using System.Collections.Generic;
     using System.Reflection;
     using NLog;
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium;
     using OpenQA.Selenium.Remote;
     using TestProject.OpenSDK.Internal.Addons;
@@ -35,8 +34,8 @@ namespace TestProject.OpenSDK.Drivers.IOS
     /// Driver.
     /// </summary>
     /// <typeparam name="T">Type.</typeparam>
-    public class IOSDriver<T> : OpenQA.Selenium.Appium.iOS.IOSDriver<T>, ITestProjectDriver, IHasTouchScreen
-        where T : IWebElement
+    public class IOSDriver<T> : OpenQA.Selenium.Appium.iOS.IOSDriver<T>, IWebDriver, OpenQA.Selenium.IHasTouchScreen
+        where T : OpenQA.Selenium.IWebElement
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
@@ -46,7 +45,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
         /// <summary>
         /// Allows execution of basic touch screen operations.
         /// </summary>
-        public ITouchScreen TouchScreen { get; }
+        public OpenQA.Selenium.ITouchScreen TouchScreen { get; }
 
         private readonly DriverShutdownThread driverShutdownThread;
 
@@ -173,7 +172,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
             if (driverCommandToExecute.Equals(DriverCommand.NewSession))
             {
                 var resp = new Response();
-                resp.Status = WebDriverResult.Success;
+                resp.Status = OpenQA.Selenium.WebDriverResult.Success;
                 resp.SessionId = this.sessionId;
                 resp.Value = new Dictionary<string, object>();
 

--- a/TestProject.OpenSDK/Drivers/IWebDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IWebDriver.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ITestProjectDriver.cs" company="TestProject">
+﻿// <copyright file="IWebDriver.cs" company="TestProject">
 // Copyright 2020 TestProject (https://testproject.io)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,13 @@
 
 namespace TestProject.OpenSDK.Drivers
 {
+    using TestProject.OpenSDK.Internal.Addons;
+    using TestProject.OpenSDK.Internal.Reporting;
+
     /// <summary>
     /// Interface defining methods that all TestProject driver classes should implement.
     /// </summary>
-    public interface ITestProjectDriver
+    public interface IWebDriver : OpenQA.Selenium.IWebDriver
     {
         /// <summary>
         /// Flag that indicates whether or not the driver instance is running.
@@ -27,9 +30,21 @@ namespace TestProject.OpenSDK.Drivers
         bool IsRunning { get; }
 
         /// <summary>
+        /// Enables access to the TestProject reporting actions from the driver object.
+        /// </summary>
+        /// <returns><see cref="Reporter"/> object exposing TestProject reporting methods.</returns>
+        Reporter Report();
+
+        /// <summary>
+        /// Enables access to the TestProject addon execution actions from the driver object.
+        /// </summary>
+        /// <returns><see cref="AddonHelper"/> object exposing TestProject action execution methods.</returns>
+        AddonHelper Addons();
+
+        /// <summary>
         /// Quits the driver and stops the session with the Agent, cleaning up after itself.
         /// </summary>
-        void Quit();
+        new void Quit();
 
         /// <summary>
         /// Sends any pending reports and closes the browser session.

--- a/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/Threading/DriverShutdownThread.cs
@@ -27,7 +27,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.Threading
     {
         private static int priorityCounter = 0;
 
-        private ITestProjectDriver driver;
+        private IWebDriver driver;
         private int priority;
 
         private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
@@ -36,7 +36,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.Threading
         /// Initializes a new instance of the <see cref="DriverShutdownThread"/> class.
         /// </summary>
         /// <param name="driver">The driver object to shutdown gracefully.</param>
-        public DriverShutdownThread(ITestProjectDriver driver)
+        public DriverShutdownThread(IWebDriver driver)
             : base()
         {
             this.driver = driver;


### PR DESCRIPTION
This PR renames the `ITestProjectDriver` interface to `IWebDriver` and enhances it so it can be used in multi-browser tests. See issue 144 for the reasoning behind this PR.