### PR TITLE
Fix/150 project job name inferring from constructors

### DIFF
--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/MSTestStackTraceHelperTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/MSTestStackTraceHelperTest.cs
@@ -25,8 +25,20 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
     [TestClass]
     public class MSTestStackTraceHelperTest
     {
+        private readonly string projectNameFromConstructor;
+        private readonly string jobNameFromConstructor;
+
         private string projectNameFromTestInitialize;
         private string jobNameFromTestInitialize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MSTestStackTraceHelperTest"/> class.
+        /// </summary>
+        public MSTestStackTraceHelperTest()
+        {
+            this.projectNameFromConstructor = StackTraceHelper.Instance.GetInferredProjectName();
+            this.jobNameFromConstructor = StackTraceHelper.Instance.GetInferredJobName();
+        }
 
         /// <summary>
         /// Infer the project and job name from within a [TestInitialize] method for later verification.
@@ -98,6 +110,24 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
         public void CheckInferredJobNameFromTestInitialize_ShouldEqualCurrentTestClass()
         {
             Assert.AreEqual("MSTestStackTraceHelperTest", this.jobNameFromTestInitialize);
+        }
+
+        /// <summary>
+        /// Inferring the project name inside an MSTest test class constructor should return the expected value.
+        /// </summary>
+        [TestMethod]
+        public void GetInferredProjectNameFromConstructor_CheckResult_ShouldEqualFinalPartOfCurrentNamespace()
+        {
+            Assert.AreEqual("CallStackAnalysis", this.projectNameFromConstructor);
+        }
+
+        /// <summary>
+        /// Inferring the job name inside an MSTest test class constructor should return the expected value.
+        /// </summary>
+        [TestMethod]
+        public void GetInferredJobNameFromConstructor_CheckResult_ShouldEqualCurrentTestClass()
+        {
+            Assert.AreEqual("MSTestStackTraceHelperTest", this.jobNameFromConstructor);
         }
     }
 }

--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/NUnitStackTraceHelperTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/NUnitStackTraceHelperTest.cs
@@ -25,8 +25,20 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
     [TestFixture]
     public class NUnitStackTraceHelperTest
     {
+        private readonly string projectNameFromConstructor;
+        private readonly string jobNameFromConstructor;
+
         private string projectNameFromSetUp;
         private string jobNameFromSetUp;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NUnitStackTraceHelperTest"/> class.
+        /// </summary>
+        public NUnitStackTraceHelperTest()
+        {
+            this.projectNameFromConstructor = StackTraceHelper.Instance.GetInferredProjectName();
+            this.jobNameFromConstructor = StackTraceHelper.Instance.GetInferredJobName();
+        }
 
         /// <summary>
         /// Infer the project and job name from within a [SetUp] method for later verification.
@@ -98,6 +110,24 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
         public void CheckInferredJobNameFromTestInitialize_ShouldEqualCurrentTestClass()
         {
             Assert.AreEqual("NUnitStackTraceHelperTest", this.jobNameFromSetUp);
+        }
+
+        /// <summary>
+        /// Inferring the project name inside an NUnit test class constructor should return the expected value.
+        /// </summary>
+        [Test]
+        public void GetInferredProjectNameFromConstructor_CheckResult_ShouldEqualFinalPartOfCurrentNamespace()
+        {
+            Assert.AreEqual("CallStackAnalysis", this.projectNameFromConstructor);
+        }
+
+        /// <summary>
+        /// Inferring the job name inside an NUnit test class constructor should return the expected value.
+        /// </summary>
+        [Test]
+        public void GetInferredJobNameFromConstructor_CheckResult_ShouldEqualCurrentTestClass()
+        {
+            Assert.AreEqual("NUnitStackTraceHelperTest", this.jobNameFromConstructor);
         }
     }
 }

--- a/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/XUnitStackTraceHelperTest.cs
+++ b/TestProject.OpenSDK.Tests/UnitTests/Internal/CallStackAnalysis/XUnitStackTraceHelperTest.cs
@@ -24,6 +24,18 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
     /// </summary>
     public class XUnitStackTraceHelperTest
     {
+        private readonly string projectNameFromConstructor;
+        private readonly string jobNameFromConstructor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XUnitStackTraceHelperTest"/> class.
+        /// </summary>
+        public XUnitStackTraceHelperTest()
+        {
+            this.projectNameFromConstructor = StackTraceHelper.Instance.GetInferredProjectName();
+            this.jobNameFromConstructor = StackTraceHelper.Instance.GetInferredJobName();
+        }
+
         /// <summary>
         /// Inferring the current test name should return the expected value.
         /// </summary>
@@ -66,6 +78,24 @@ namespace TestProject.OpenSDK.Tests.UnitTests.Internal.CallStackAnalysis
             string projectName = StackTraceHelper.Instance.GetInferredProjectName();
 
             Assert.Equal("CallStackAnalysis", projectName);
+        }
+
+        /// <summary>
+        /// Inferring the project name inside an XUnit test class constructor should return the expected value.
+        /// </summary>
+        [Fact]
+        public void GetInferredProjectNameFromConstructor_CheckResult_ShouldEqualFinalPartOfCurrentNamespace()
+        {
+            Assert.Equal("CallStackAnalysis", this.projectNameFromConstructor);
+        }
+
+        /// <summary>
+        /// Inferring the job name inside an XUnit test class constructor should return the expected value.
+        /// </summary>
+        [Fact]
+        public void GetInferredJobNameFromConstructor_CheckResult_ShouldEqualCurrentTestClass()
+        {
+            Assert.Equal("XUnitStackTraceHelperTest", this.jobNameFromConstructor);
         }
     }
 }


### PR DESCRIPTION
This PR addresses the issue where project and job name inferring from within a test class constructor yielded incorrect results. See issue 150 and the unit tests added in this PR for more information / documentation.