### PR TITLE
Allow to control report type - local, cloud or both

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,18 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2021-04-01
+
+### Added
+
+- ([#157](https://github.com/testproject-io/csharp-opensdk/issues/157)) - Allow controlling report type - local / cloud or both.
+- ([#158](https://github.com/testproject-io/csharp-opensdk/issues/158)) - Added DriverBuilder.
 
 ## [0.66.0] - 2021-03-19
 
@@ -27,14 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ([#129](https://github.com/testproject-io/csharp-opensdk/issues/129)) - The IWebDriver object must implement or wrap a driver that implements IHasTouchScreen
 - ([#127](https://github.com/testproject-io/csharp-opensdk/issues/127)) - Implicit timeout command is not reported in the proper test
 - ([#125](https://github.com/testproject-io/csharp-opensdk/issues/125)) - ResetApp throws System.NullReferenceException
-- ([#123](https://github.com/testproject-io/csharp-opensdk/issues/123)) - Failing driver command is not reported when using implicit wait 
+- ([#123](https://github.com/testproject-io/csharp-opensdk/issues/123)) - Failing driver command is not reported when using implicit wait
 - ([#117](https://github.com/testproject-io/csharp-opensdk/issues/117)) - [NUnit] elementDictionary (Parameter 'The specified dictionary does not contain an element reference')'
 - ([#109](https://github.com/testproject-io/csharp-opensdk/issues/109)) - SDK throws NullReferenceException when agent isn't running
 - ([#106](https://github.com/testproject-io/csharp-opensdk/issues/106)) - All Scenarios and Steps are under a single test when using GenericDriver with SpecFlow plugin
 - ([#103](https://github.com/testproject-io/csharp-opensdk/issues/103)) - When TP_KEEP_DRIVER_SESSION is set, test names are not reported
 - ([#91](https://github.com/testproject-io/csharp-opensdk/issues/91)) - Generated reports on xunit contain wrong test details
 - ([#90](https://github.com/testproject-io/csharp-opensdk/issues/90)) - driver.ExecuteScript fails when using driver from OpenSDK
-- ([#89](https://github.com/testproject-io/csharp-opensdk/issues/89)) - element.GetAttribute(*) returns null when using FirefoxDriver
+- ([#89](https://github.com/testproject-io/csharp-opensdk/issues/89)) - element.GetAttribute(\*) returns null when using FirefoxDriver
 - ([#88](https://github.com/testproject-io/csharp-opensdk/issues/88)) - Test name in report is wrong (after using driver.Quit())
 - ([#87](https://github.com/testproject-io/csharp-opensdk/issues/87)) - Updated incorrect code samples in README.md
 - ([#85](https://github.com/testproject-io/csharp-opensdk/issues/85)) - Stub OpenSDK C# test fails in ChromeDriver constructor

--- a/README.md
+++ b/README.md
@@ -222,6 +222,34 @@ driver.Report().DisableCommandReports(DriverCommandsFilter.All);
 
 will result in a report with no steps, unless they are reported manually using `driver.Report().Step()`.
 
+## Cloud and Local Report
+
+By default, the execution report is uploaded to the cloud, and a local report is created, as an HTML file in a temporary folder.
+
+At the end of execution, the report is uploaded to the cloud and SDK outputs to the console/terminal the path for a local report file:
+
+`Execution Report: {temporary_folder}/report.html`
+
+This behavior can be controlled, by requesting only a `LOCAL` or only a `CLOUD` report.
+
+> When the Agent is offline, and only a _cloud_ report is requested, execution will fail with appropriate message.
+
+Via a driver constructor:
+
+```csharp
+var driver = new ChromeDriver(chromeOptions: new ChromeOptions(), reportType: ReportType.LOCAL);
+```
+
+Via Driver Builder:
+
+```csharp
+var driver = new DriverBuilder<FirefoxDriver>()
+    .WithJobName("DriverBuilder Job")
+    .WithProjectName("TestProject C# OpenSDK")
+    .WithReportType(ReportType.LOCAL)
+    .Build();
+```
+
 ### Disable command redaction
 
 When reporting driver commands, the OpenSDK performs redaction of sensitive data (values) sent to secured elements. If the element is one of the following:

--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -68,16 +68,18 @@ namespace TestProject.OpenSDK.Drivers.Android
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public AndroidDriver(
             Uri remoteAddress = null,
             string token = null,
             AppiumOptions appiumOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
             : base(
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.RemoteAddress,
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.Capabilities)
+                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.RemoteAddress,
+                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.Capabilities)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 

--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -66,15 +66,17 @@ namespace TestProject.OpenSDK.Drivers
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         protected BaseDriver(
             Uri remoteAddress = null,
             string token = null,
             DriverOptions driverOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
             : base(
-                  AgentClient.GetInstance(remoteAddress, token, driverOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.Capabilities)
+                  AgentClient.GetInstance(remoteAddress, token, driverOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.Capabilities)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 

--- a/TestProject.OpenSDK/Drivers/DriverBuilder.cs
+++ b/TestProject.OpenSDK/Drivers/DriverBuilder.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers
     using System;
     using NLog;
     using OpenQA.Selenium;
+    using TestProject.OpenSDK.Enums;
 
     /// <summary>
     /// Utility class to build Driver instances.
@@ -60,6 +61,11 @@ namespace TestProject.OpenSDK.Drivers
         /// Enable/Disable reports.
         /// </summary>
         private bool builderDisableReports;
+
+        /// <summary>
+        /// Set report type to Cloud, Local or Both.
+        /// </summary>
+        private ReportType builderReportType = ReportType.CLOUD_AND_LOCAL;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DriverBuilder{T}"/> class.
@@ -137,6 +143,17 @@ namespace TestProject.OpenSDK.Drivers
         }
 
         /// <summary>
+        /// Set Report Type to Cloud, Local or Both.
+        /// </summary>
+        /// <param name="reportType">Type of Report to generate.</param>
+        /// <returns>Modified DriverBuilder instance.</returns>
+        public DriverBuilder<T> WithReportType(ReportType reportType)
+        {
+            this.builderReportType = reportType;
+            return this;
+        }
+
+        /// <summary>
         /// Builds an instance of the requested driver using set values.
         /// </summary>
         /// <returns>Driver instance.</returns>
@@ -151,7 +168,8 @@ namespace TestProject.OpenSDK.Drivers
                     this.builderOptions,
                     this.builderProjectName,
                     this.builderJobName,
-                    this.builderDisableReports);
+                    this.builderDisableReports,
+                    this.builderReportType);
             } catch (Exception)
             {
                 throw new WebDriverException($"Failed to create an instance of {typeof(T)}");

--- a/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
@@ -57,14 +57,16 @@ namespace TestProject.OpenSDK.Drivers.Generic
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public GenericDriver(
             Uri remoteAddress = null,
             string token = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
         {
-            AgentClient agentClient = AgentClient.GetInstance(remoteAddress, token, new GenericOptions(), new ReportSettings(projectName, jobName), disableReports, this.minGenericDriverSupportedVersion);
+            AgentClient agentClient = AgentClient.GetInstance(remoteAddress, token, new GenericOptions(), new ReportSettings(projectName, jobName, reportType), disableReports, this.minGenericDriverSupportedVersion);
 
             this.commandExecutor = new GenericCommandExecutor(remoteAddress, disableReports);
 

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -68,16 +68,18 @@ namespace TestProject.OpenSDK.Drivers.IOS
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public IOSDriver(
             Uri remoteAddress = null,
             string token = null,
             AppiumOptions appiumOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
             : base(
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.RemoteAddress,
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName), disableReports).AgentSession.Capabilities)
+                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.RemoteAddress,
+                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.Capabilities)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 

--- a/TestProject.OpenSDK/Drivers/Web/ChromeDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/ChromeDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Web
 {
     using System;
     using OpenQA.Selenium.Chrome;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
 
     /// <summary>
@@ -35,14 +36,16 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public ChromeDriver(
             Uri remoteAddress = null,
             string token = null,
             ChromeOptions chromeOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(chromeOptions, BrowserType.Chrome), projectName, jobName, disableReports)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(chromeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/EdgeDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/EdgeDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Web
 {
     using System;
     using OpenQA.Selenium.Edge;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
 
     /// <summary>
@@ -35,14 +36,16 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public EdgeDriver(
             Uri remoteAddress = null,
             string token = null,
             EdgeOptions edgeOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(edgeOptions, BrowserType.Edge), projectName, jobName, disableReports)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(edgeOptions, BrowserType.Edge), projectName, jobName, disableReports, reportType)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/FirefoxDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/FirefoxDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Web
 {
     using System;
     using OpenQA.Selenium.Firefox;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
 
     /// <summary>
@@ -35,14 +36,16 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public FirefoxDriver(
             Uri remoteAddress = null,
             string token = null,
             FirefoxOptions firefoxOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(firefoxOptions, BrowserType.Firefox), projectName, jobName, disableReports)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(firefoxOptions, BrowserType.Firefox), projectName, jobName, disableReports, reportType)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/InternetExplorerDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/InternetExplorerDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Web
 {
     using System;
     using OpenQA.Selenium.IE;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
 
     /// <summary>
@@ -35,14 +36,16 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public InternetExplorerDriver(
             Uri remoteAddress = null,
             string token = null,
             InternetExplorerOptions internetExplorerOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(internetExplorerOptions, BrowserType.InternetExplorer), projectName, jobName, disableReports)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(internetExplorerOptions, BrowserType.InternetExplorer), projectName, jobName, disableReports, reportType)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/RemoteWebDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/RemoteWebDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Web
 {
     using System;
     using OpenQA.Selenium;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
 
     /// <summary>
@@ -35,14 +36,16 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public RemoteWebDriver(
             Uri remoteAddress = null,
             string token = null,
             DriverOptions driverOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(driverOptions, BrowserType.Remote), projectName, jobName, disableReports)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(driverOptions, BrowserType.Remote), projectName, jobName, disableReports, reportType)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/SafariDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/SafariDriver.cs
@@ -18,6 +18,7 @@ namespace TestProject.OpenSDK.Drivers.Web
 {
     using System;
     using OpenQA.Selenium.Safari;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
 
     /// <summary>
@@ -35,14 +36,16 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="disableReports">Set to true to disable all reporting (no report will be created on TestProject).</param>
+        /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         public SafariDriver(
             Uri remoteAddress = null,
             string token = null,
             SafariOptions safariOptions = null,
             string projectName = null,
             string jobName = null,
-            bool disableReports = false)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(safariOptions, BrowserType.Safari), projectName, jobName, disableReports)
+            bool disableReports = false,
+            ReportType reportType = ReportType.CLOUD_AND_LOCAL)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(safariOptions, BrowserType.Safari), projectName, jobName, disableReports, reportType)
         {
         }
     }

--- a/TestProject.OpenSDK/Enums/ReportType.cs
+++ b/TestProject.OpenSDK/Enums/ReportType.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="ReportType.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Enums
+{
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// Enum class which defines the type of Generated Report for the execution.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum ReportType
+    {
+        /// <summary>
+        /// Cloud only report.
+        /// </summary>
+        CLOUD,
+
+        /// <summary>
+        /// Local only report.
+        /// </summary>
+        LOCAL,
+
+        /// <summary>
+        /// Both - Cloud and Local report.
+        /// </summary>
+        CLOUD_AND_LOCAL,
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -19,6 +19,7 @@ namespace TestProject.OpenSDK.Internal.Rest
     using System;
     using System.Collections.Generic;
     using System.Net;
+    using System.Text;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using NLog;
@@ -31,6 +32,7 @@ namespace TestProject.OpenSDK.Internal.Rest
     using OpenQA.Selenium.Safari;
     using RestSharp;
     using TestProject.OpenSDK.Drivers.Generic;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Exceptions;
     using TestProject.OpenSDK.Internal.Addons;
     using TestProject.OpenSDK.Internal.CallStackAnalysis;
@@ -83,6 +85,11 @@ namespace TestProject.OpenSDK.Internal.Rest
         /// The default timeout in milliseconds for the <see cref="RestClient"/> class.
         /// </summary>
         private readonly int defaultRestClientTimeoutInMilliseconds = 100 * 1000;
+
+        /// <summary>
+        /// Minimum agent version that supports local reports.
+        /// </summary>
+        private readonly Version minLocalReportSupportedVersion = new Version("2.1.0");
 
         /// <summary>
         /// The current version of the Agent in use.
@@ -211,6 +218,9 @@ namespace TestProject.OpenSDK.Internal.Rest
             this.reportsQueue = new ReportsQueue(this.client);
 
             this.StartSession(sessionReportSettings, capabilities);
+
+            // Verify the agent version supports local report generation
+            this.VerifyIfLocalReportsIsSupported(reportSettings.ReportType);
         }
 
         /// <summary>
@@ -581,7 +591,7 @@ namespace TestProject.OpenSDK.Internal.Rest
         /// <summary>
         /// Tries to infer report settings using the <see cref="StackTraceHelper"/> and returns resulting reporting settings.
         /// </summary>
-        /// <param name="originalSettings">The explicitly specified project and job names (may be null or empty).</param>
+        /// <param name="originalSettings">The explicitly specified project and job names (may be null or empty) and the report type if set.</param>
         /// <returns><see cref="ReportSettings"/> instance with inferred project and job names (where applicable).</returns>
         private ReportSettings InferReportSettings(ReportSettings originalSettings)
         {
@@ -590,6 +600,7 @@ namespace TestProject.OpenSDK.Internal.Rest
                 !string.IsNullOrEmpty(originalSettings.ProjectName))
             {
                 Logger.Trace("Project and job names were explicitly specified, skipping inferring.");
+                Logger.Trace($"Report Type was set to {originalSettings.ReportType}");
                 return originalSettings;
             }
 
@@ -603,19 +614,40 @@ namespace TestProject.OpenSDK.Internal.Rest
             if (originalSettings == null)
             {
                 // Create ReportSettings
-                inferredReportSettings = new ReportSettings(projectName, jobName);
+                inferredReportSettings = new ReportSettings(projectName, jobName, ReportType.CLOUD_AND_LOCAL);
             }
             else
             {
-                // Overwrite empty values with inferred ones
+                // Overwrite empty values with inferred ones, Report type is either the default value or supplied one
                 inferredReportSettings = new ReportSettings(
                     string.IsNullOrEmpty(originalSettings.ProjectName) ? projectName : originalSettings.ProjectName,
-                    string.IsNullOrEmpty(originalSettings.JobName) ? jobName : originalSettings.JobName);
+                    string.IsNullOrEmpty(originalSettings.JobName) ? jobName : originalSettings.JobName,
+                    originalSettings.ReportType);
             }
 
             Logger.Trace($"Using inferred values '{inferredReportSettings.ProjectName}' and '{inferredReportSettings.JobName}' as project and job name, respectively.");
+            Logger.Trace($"Report Type was set to {inferredReportSettings.ReportType}.");
 
             return inferredReportSettings;
+        }
+
+        /// <summary>
+        /// Verify whether the current Agent version supports local report generation.
+        /// </summary>
+        /// <param name="reportType">The request Report Type.</param>
+        /// <throws>AgentConnectionException if the current agent version older than <see cref="minLocalReportSupportedVersion"/>.</returns>
+        private void VerifyIfLocalReportsIsSupported(ReportType reportType)
+        {
+            if (reportType == ReportType.LOCAL && this.agentVersion.CompareTo(this.minLocalReportSupportedVersion) < 0)
+            {
+                StringBuilder message = new StringBuilder()
+                    .Append("Target Agent version")
+                    .Append(" [").Append(this.agentVersion)
+                    .Append("] ")
+                    .Append("doesn't support local reports. ")
+                    .Append("Upgrade the Agent to the latest version and try again.");
+                throw new AgentConnectException(message.ToString());
+            }
         }
 
         /// <summary>

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -122,6 +122,11 @@ namespace TestProject.OpenSDK.Internal.Rest
         private ReportsQueue reportsQueue;
 
         /// <summary>
+        /// Response from the starting of the agent session.
+        /// </summary>
+        private SessionResponse sessionResponse;
+
+        /// <summary>
         /// Logger instance for this class.
         /// </summary>
         private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
@@ -221,6 +226,11 @@ namespace TestProject.OpenSDK.Internal.Rest
 
             // Verify the agent version supports local report generation
             this.VerifyIfLocalReportsIsSupported(reportSettings.ReportType);
+
+            if (!string.IsNullOrEmpty(this.sessionResponse.LocalReport))
+            {
+                Logger.Info($"Execution Report: {this.sessionResponse.LocalReport}");
+            }
         }
 
         /// <summary>
@@ -462,6 +472,7 @@ namespace TestProject.OpenSDK.Internal.Rest
             this.AgentSession = new AgentSession(serverAddress, sessionResponse.SessionId, sessionResponse.Dialect, options);
 
             Logger.Info($"Session [{sessionResponse.SessionId}] initialized");
+            this.sessionResponse = sessionResponse;
         }
 
         private void OpenSocketConnectionUsing(SessionResponse sessionResponse)

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionRequest.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionRequest.cs
@@ -19,6 +19,7 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
     using System.Collections.Generic;
     using OpenQA.Selenium;
     using TestProject.OpenSDK.Drivers.Generic;
+    using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers;
 
     /// <summary>
@@ -52,6 +53,11 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         public string JobName { get; }
 
         /// <summary>
+        /// The report type, can be local, cloud or both.
+        /// </summary>
+        public ReportType ReportType { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SessionRequest"/> class.
         /// </summary>
         /// <param name="reportSettings">Report settings with the project and job names to report.</param>
@@ -62,6 +68,7 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
             {
                 this.ProjectName = reportSettings.ProjectName;
                 this.JobName = reportSettings.JobName;
+                this.ReportType = reportSettings.ReportType;
             }
 
             // Convert DriverOptions to a format that preserves arguments and extensions when serializing it.

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
@@ -51,6 +51,6 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         /// <summary>
         /// The local report generated.
         /// </summary>
-        public string LocalReport { get; }
+        public string LocalReport { get; set; }
     }
 }

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
@@ -47,5 +47,10 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         /// The current version of the Agent.
         /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// The local report generated.
+        /// </summary>
+        public string LocalReport { get; }
     }
 }

--- a/TestProject.OpenSDK/Internal/Rest/ReportSettings.cs
+++ b/TestProject.OpenSDK/Internal/Rest/ReportSettings.cs
@@ -16,6 +16,8 @@
 
 namespace TestProject.OpenSDK.Internal.Rest
 {
+    using TestProject.OpenSDK.Enums;
+
     /// <summary>
     /// Report settings model provided to the Agent upon session initialization.
     /// </summary>
@@ -32,14 +34,21 @@ namespace TestProject.OpenSDK.Internal.Rest
         public string JobName { get; }
 
         /// <summary>
+        /// The report type of the execution.
+        /// </summary>
+        public ReportType ReportType { get;  }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ReportSettings"/> class.
         /// </summary>
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
-        public ReportSettings(string projectName, string jobName)
+        /// <param name="reportType">The report type of the execution (local, cloud, both).</param>
+        public ReportSettings(string projectName, string jobName, ReportType reportType)
         {
             this.ProjectName = projectName;
             this.JobName = jobName;
+            this.ReportType = reportType;
         }
     }
 }


### PR DESCRIPTION
Added support for control of report generation, which can be local, cloud or by default, both for supported agent versions.