### PR TITLE
Add null check for namespace when inferring project name

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ([#161](https://github.com/testproject-io/csharp-opensdk/issues/161)) - Fix for Agent Session reuse, tests with the same Project name and Job name will be aggregated in the Test Report.
+- ([#160](https://github.com/testproject-io/csharp-opensdk/issues/160)) - Added a null check on infered Specflow project name when using the BeforeTestRun annotation.
 - ([#159](https://github.com/testproject-io/csharp-opensdk/issues/159)) - Fix for Skipped reports if the Specflow plugin was not installed, will now show a clear error message.
- - 
+
 ## [1.0.0] - 2021-04-01
 
 ### Added

--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
@@ -67,7 +67,7 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         {
             MethodBase method = this.TryDetectSetupMethod() ?? this.TryDetectTestMethod() ?? this.TryDetectConstructor() ?? this.GetTestMethod();
 
-            return method.DeclaringType.Namespace.Split('.').Last();
+            return method.DeclaringType.Namespace?.Split('.').Last() ?? "My Project";
         }
 
         /// <summary>


### PR DESCRIPTION
This is required when Specflow tests use the BeforeTestRun annotation which generates a class without a namespace, hence causing a nullpointer when trying to infer the project name.

Signed-off-by: Ran Tzur <ran.tzur@testproject.io>