### PR TITLE
Fix session reuse logic to support multiple agent session reuse

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ([#161](https://github.com/testproject-io/csharp-opensdk/issues/161)) - Fix for Agent Session reuse, tests with the same Project name and Job name will be aggregated in the Test Report.
+- ([#159](https://github.com/testproject-io/csharp-opensdk/issues/159)) - Fix for Skipped reports if the Specflow plugin was not installed, will now show a clear error message.
+ - 
 ## [1.0.0] - 2021-04-01
 
 ### Added

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
@@ -87,8 +87,13 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
 
             if (isQuitCommand)
             {
-                // Close the client after finishing the test using driver.Quit()
-                AgentClient.GetInstance().Stop();
+                var instance = AgentClient.GetInstance();
+
+                // Send SpecFlow test report, if exists.
+                if (instance.SpecFlowTestReport != null)
+                {
+                    instance.ReportTest(instance.SpecFlowTestReport);
+                }
 
                 // Do not report Quit() command to avoid creating a new test in the reports
                 return;

--- a/TestProject.OpenSDK/Internal/Rest/ReportSettings.cs
+++ b/TestProject.OpenSDK/Internal/Rest/ReportSettings.cs
@@ -44,11 +44,33 @@ namespace TestProject.OpenSDK.Internal.Rest
         /// <param name="projectName">The project name to report.</param>
         /// <param name="jobName">The job name to report.</param>
         /// <param name="reportType">The report type of the execution (local, cloud, both).</param>
-        public ReportSettings(string projectName, string jobName, ReportType reportType)
+        public ReportSettings(string projectName, string jobName, ReportType reportType = ReportType.CLOUD_AND_LOCAL)
         {
             this.ProjectName = projectName;
             this.JobName = jobName;
             this.ReportType = reportType;
         }
+
+        /// <summary>
+        /// Override equals method of <see cref="ReportSettings"/> class.
+        /// </summary>
+        /// <param name="obj">Target object to compare to.</param>
+        /// <returns> True if both objects are equal, false otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+
+            if (obj == null || !this.GetType().Name.Equals(obj.GetType().Name))
+            {
+                return false;
+            }
+
+            ReportSettings that = obj as ReportSettings;
+            return object.Equals(this.ProjectName, that.ProjectName) && object.Equals(this.JobName, that.JobName);
+        }
+
     }
 }


### PR DESCRIPTION
This is a fix for the workaround applied on https://github.com/testproject-io/csharp-opensdk/pull/158/commits/6ed6f973ecaff3e0206367e000dbcb5f9df83643

To reuse agent session to bundle reports of tests with the same Project name and job.