### PR TITLE
Fix for mobile driver initialization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ([#162](https://github.com/testproject-io/csharp-opensdk/issues/162)) - Fix for AgentClient creation on Mobile tests, it will now reuse the previously created session in the constructor.
 - ([#161](https://github.com/testproject-io/csharp-opensdk/issues/161)) - Fix for Agent Session reuse, tests with the same Project name and Job name will be aggregated in the Test Report.
 - ([#160](https://github.com/testproject-io/csharp-opensdk/issues/160)) - Added a null check on infered Specflow project name when using the BeforeTestRun annotation.
 - ([#159](https://github.com/testproject-io/csharp-opensdk/issues/159)) - Fix for Skipped reports if the Specflow plugin was not installed, will now show a clear error message.

--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -79,8 +79,8 @@ namespace TestProject.OpenSDK.Drivers.Android
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL)
             : base(
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.RemoteAddress,
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.Capabilities)
+                  AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.RemoteAddress,
+                  AgentClient.GetInstance().AgentSession.Capabilities)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -79,8 +79,8 @@ namespace TestProject.OpenSDK.Drivers.IOS
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL)
             : base(
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.RemoteAddress,
-                AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.Capabilities)
+                  AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType), disableReports).AgentSession.RemoteAddress,
+                  AgentClient.GetInstance().AgentSession.Capabilities)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 


### PR DESCRIPTION
Instead of calling the Constructor of the agent client twice in the base method call, it will now re use the previously created session.

Signed-off-by: Ran Tzur <ran.tzur@testproject.io>