### PR TITLE
Avoid closing AgentClient instance when stopping the driver

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ([#164](https://github.com/testproject-io/csharp-opensdk/issues/164)) - Fix for GenericDriver multitest session reuse.
 - ([#162](https://github.com/testproject-io/csharp-opensdk/issues/162)) - Fix for AgentClient creation on Mobile tests, it will now reuse the previously created session in the constructor.
 - ([#161](https://github.com/testproject-io/csharp-opensdk/issues/161)) - Fix for Agent Session reuse, tests with the same Project name and Job name will be aggregated in the Test Report.
 - ([#160](https://github.com/testproject-io/csharp-opensdk/issues/160)) - Added a null check on infered Specflow project name when using the BeforeTestRun annotation.

--- a/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
@@ -127,8 +127,6 @@ namespace TestProject.OpenSDK.Drivers.Generic
             }
 
             this.IsRunning = false;
-
-            AgentClient.GetInstance().Stop();
         }
     }
 }


### PR DESCRIPTION
This is a fix for https://github.com/testproject-io/csharp-opensdk/issues/163

Signed-off-by: Ran Tzur <ran.tzur@testproject.io>