### PR TITLE
Fix mobile session reuse

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ([#165](https://github.com/testproject-io/csharp-opensdk/issues/165)) - Fix for Mobile multitest agent dev session reuse.
 - ([#164](https://github.com/testproject-io/csharp-opensdk/issues/164)) - Fix for GenericDriver multitest session reuse.
 - ([#162](https://github.com/testproject-io/csharp-opensdk/issues/162)) - Fix for AgentClient creation on Mobile tests, it will now reuse the previously created session in the constructor.
 - ([#161](https://github.com/testproject-io/csharp-opensdk/issues/161)) - Fix for Agent Session reuse, tests with the same Project name and Job name will be aggregated in the Test Report.

--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -31,6 +31,7 @@ namespace TestProject.OpenSDK.Drivers.Android
     using TestProject.OpenSDK.Internal.Helpers.Threading;
     using TestProject.OpenSDK.Internal.Reporting;
     using TestProject.OpenSDK.Internal.Rest;
+    using TestProject.OpenSDK.Internal.Tcp;
 
     /// <summary>
     /// Driver.
@@ -53,7 +54,7 @@ namespace TestProject.OpenSDK.Drivers.Android
 
         private readonly string sessionId;
 
-        private readonly CustomHttpCommandExecutor commandExecutor;
+        private readonly AppiumCustomHttpCommandExecutor commandExecutor;
 
         /// <summary>
         /// Logger instance for this class.
@@ -89,7 +90,7 @@ namespace TestProject.OpenSDK.Drivers.Android
             sessionIdField.SetValue(this, new SessionId(this.sessionId));
 
             // Create a new command executor for this driver session and set disable reporting flag
-            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
+            this.commandExecutor = new AppiumCustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
 
             // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
             // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -53,7 +53,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
 
         private readonly string sessionId;
 
-        private readonly CustomHttpCommandExecutor commandExecutor;
+        private readonly AppiumCustomHttpCommandExecutor commandExecutor;
 
         /// <summary>
         /// Logger instance for this class.
@@ -89,7 +89,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
             sessionIdField.SetValue(this, new SessionId(this.sessionId));
 
             // Create a new command executor for this driver session and set disable reporting flag
-            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
+            this.commandExecutor = new AppiumCustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
 
             // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
             // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/AppiumCustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/AppiumCustomHttpCommandExecutor.cs
@@ -1,0 +1,104 @@
+﻿// <copyright file="AppiumCustomHttpCommandExecutor.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
+{
+    using System;
+    using System.Collections.Generic;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Remote;
+
+    /// <summary>
+    /// A custom commands executor for Appium drivers.
+    /// Extends the original functionality of <see cref="CustomHttpCommandExecutor"/> for appium drivers.
+    /// </summary>
+    internal class AppiumCustomHttpCommandExecutor : CustomHttpCommandExecutor
+    {
+        private bool skipReporting;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppiumCustomHttpCommandExecutor"/> class.
+        /// </summary>
+        /// <param name="addressOfRemoteServer">URL of the remote Selenium server managed by the Agent.</param>
+        /// <param name="disableReports">True if all reporting should be disabled, false otherwise.</param>
+        public AppiumCustomHttpCommandExecutor(Uri addressOfRemoteServer, bool disableReports)
+            : base(addressOfRemoteServer, disableReports)
+        {
+            this.skipReporting = disableReports;
+        }
+
+        /// <summary>
+        /// Extended command execution method for Appium drivers.
+        /// </summary>
+        /// <param name="commandToExecute">The WebDriver command to execute.</param>
+        /// <returns>The <see cref="Response"/> returned by the Agent.</returns>
+        public override Response Execute(Command commandToExecute)
+        {
+            // The Selenium HttpCommandExecutor modifies the command parameters, removing properties we need along the way
+            // We want to use the original command parameters when reporting, not the modified one after command execution.
+            var originalParameters = new Dictionary<string, object>(commandToExecute.Parameters);
+
+            Response response;
+
+            // If action is quit, report the command and return null to not abort the driver session
+            if (commandToExecute.Name.Equals(DriverCommand.Quit))
+            {
+                if (!this.skipReporting)
+                {
+                    response = new Response
+                    {
+                        SessionId = commandToExecute.SessionId.ToString(),
+                        Status = WebDriverResult.Success,
+                    };
+                    this.ReportingCommandExecutor.ReportCommand(commandToExecute, response);
+                }
+
+                // Returning null assures the quit of the base driver does not execute
+                return null;
+            }
+            else
+            {
+                try
+                {
+                    response = base.Execute(commandToExecute);
+                }
+                catch (WebDriverException)
+                {
+                    Dictionary<string, object> responseValue = new Dictionary<string, object>();
+                    responseValue.Add("error", "no such element");
+                    responseValue.Add("message", $"Unable to locate element {commandToExecute.ParametersAsJsonString}");
+
+                    response = new Response
+                    {
+                        Status = WebDriverResult.Timeout,
+                        SessionId = commandToExecute.SessionId.ToString(),
+                        Value = responseValue,
+                    };
+                }
+            }
+
+            // Create a command to report using the original parameters instead of the modified ones.
+            var commandToReport = new Command(commandToExecute.SessionId, commandToExecute.Name, originalParameters);
+
+            if (!this.skipReporting)
+            {
+                this.ReportingCommandExecutor.ReportCommand(commandToReport, response);
+            }
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
Avoid closing the driver instance on Mobile tests when agent session reuse is required.

This is done by not sending the quit method to the base appium driver.