### PR TITLE
Feat local report url

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ ChromeDriver driver = new ChromeDriver(remoteAddress: "your_address_and_port_go_
 
 It can also be set using the `TP_AGENT_URL` environment variable.
 
+**NOTE:** In order to be able to communicate with a remote agent, it must first start ready for external connectivity. /
+For further instructions on starting agent in this manner, please refer to the *External Connectivity* section [here](https://docs.testproject.io/testproject-agents/testproject-agent-cli#start)
+
 ## Driver Builder
 The SDK provides a generic builder for the drivers - `DriverBuilder`, for example:
 

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -267,9 +267,15 @@ namespace TestProject.OpenSDK.Internal.Rest
             // Verify the agent version supports local report generation
             this.VerifyIfLocalReportsIsSupported(reportSettings.ReportType);
 
-            if (!string.IsNullOrEmpty(this.sessionResponse.LocalReport))
+            // Show local report path only when executing on local agents.
+            if (this.client.BaseUrl.IsLocal())
             {
                 Logger.Info($"Execution Report: {this.sessionResponse.LocalReport}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.sessionResponse.LocalReportUrl))
+            {
+                Logger.Info($"Execution Report Link: {this.sessionResponse.LocalReportUrl}");
             }
         }
 

--- a/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/SessionResponses/SessionResponse.cs
@@ -49,8 +49,13 @@ namespace TestProject.OpenSDK.Internal.Rest.Messages
         public string Version { get; set; }
 
         /// <summary>
-        /// The local report generated.
+        /// Path to the local report.
         /// </summary>
         public string LocalReport { get; set; }
+
+        /// <summary>
+        /// The URL to download the local report from a remote agent.
+        /// </summary>
+        public string LocalReportUrl { get; set; }
     }
 }

--- a/TestProject.OpenSDK/Internal/Rest/UriExtensions.cs
+++ b/TestProject.OpenSDK/Internal/Rest/UriExtensions.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="UriExtensions.cs" company="TestProject">
+// Copyright 2021 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Extension methods for SessionResponse.
+    /// </summary>
+    internal static class UriExtensions
+    {
+        private static readonly string[] LocalAddresses = { "localhost", "127.0.0.1", "0.0.0.0" };
+
+        /// <summary>
+        /// Checks if session is open on a local agent. Null URI are considered a local based on their use in AgentClient.
+        /// </summary>
+        /// <param name="uri">This session response</param>
+        /// <returns>True if local session.</returns>
+        internal static bool IsLocal(this Uri uri) =>
+            uri == null || LocalAddresses.Any(a => uri.Host.Contains(a));
+    }
+}


### PR DESCRIPTION
This PR implements the requested changes in https://github.com/testproject-io/csharp-opensdk/issues/171, including support for the new report URL and hiding the local report path when working against remote agent.