### PR TITLE
Allow overriding remote connection timeout via driver constructor

### DIFF
--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -72,6 +72,7 @@ namespace TestProject.OpenSDK.Drivers.Android
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">Timeout for the remote connection to the WebDriver server executing the commands.</param>
         public AndroidDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -81,10 +82,12 @@ namespace TestProject.OpenSDK.Drivers.Android
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
             : base(
                   AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports).AgentSession.RemoteAddress,
-                  AgentClient.GetInstance().AgentSession.Capabilities)
+                  AgentClient.GetInstance().AgentSession.Capabilities,
+                  remoteConnectionTimeout ?? DefaultCommandTimeout)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 
@@ -93,7 +96,7 @@ namespace TestProject.OpenSDK.Drivers.Android
             sessionIdField.SetValue(this, new SessionId(this.sessionId));
 
             // Create a new command executor for this driver session and set disable reporting flag
-            this.commandExecutor = new AppiumCustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
+            this.commandExecutor = new AppiumCustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports, remoteConnectionTimeout ?? AgentClient.DefaultConnectionTimeout);
 
             // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
             // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).

--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -92,7 +92,7 @@ namespace TestProject.OpenSDK.Drivers
             sessionIdField.SetValue(this, new SessionId(this.sessionId));
 
             // Create a new command executor for this driver session and set disable reporting flag
-            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports, remoteConnectionTimeout ?? TimeSpan.FromSeconds(60));
+            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports, remoteConnectionTimeout ?? AgentClient.DefaultConnectionTimeout);
 
             // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
             // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).

--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -70,6 +70,7 @@ namespace TestProject.OpenSDK.Drivers
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         protected BaseDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -79,7 +80,8 @@ namespace TestProject.OpenSDK.Drivers
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
             : base(
                   AgentClient.GetInstance(remoteAddress, token, driverOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports).AgentSession.Capabilities)
         {
@@ -90,7 +92,7 @@ namespace TestProject.OpenSDK.Drivers
             sessionIdField.SetValue(this, new SessionId(this.sessionId));
 
             // Create a new command executor for this driver session and set disable reporting flag
-            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
+            this.commandExecutor = new CustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports, remoteConnectionTimeout ?? TimeSpan.FromSeconds(60));
 
             // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
             // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -72,6 +72,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">Timeout for the remote connection to the WebDriver server executing the commands.</param>
         public IOSDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -81,10 +82,12 @@ namespace TestProject.OpenSDK.Drivers.IOS
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
             : base(
                   AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports).AgentSession.RemoteAddress,
-                  AgentClient.GetInstance().AgentSession.Capabilities)
+                  AgentClient.GetInstance().AgentSession.Capabilities,
+                  remoteConnectionTimeout ?? DefaultCommandTimeout)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 
@@ -93,7 +96,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
             sessionIdField.SetValue(this, new SessionId(this.sessionId));
 
             // Create a new command executor for this driver session and set disable reporting flag
-            this.commandExecutor = new AppiumCustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports);
+            this.commandExecutor = new AppiumCustomHttpCommandExecutor(AgentClient.GetInstance().AgentSession.RemoteAddress, disableReports, remoteConnectionTimeout ?? AgentClient.DefaultConnectionTimeout);
 
             // If the driver returned by the Agent is in W3C mode, we need to update the command info repository
             // associated with the base RemoteWebDriver to the W3C command info repository (default is OSS).

--- a/TestProject.OpenSDK/Drivers/Web/ChromeDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/ChromeDriver.cs
@@ -39,6 +39,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         public ChromeDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -48,8 +49,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(chromeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(chromeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/EdgeDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/EdgeDriver.cs
@@ -39,6 +39,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         public EdgeDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -48,8 +49,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(edgeOptions, BrowserType.Edge), projectName, jobName, disableReports, reportType, reportName, reportPath)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(edgeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/FirefoxDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/FirefoxDriver.cs
@@ -39,6 +39,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         public FirefoxDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -48,8 +49,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(firefoxOptions, BrowserType.Firefox), projectName, jobName, disableReports, reportType, reportName, reportPath)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(firefoxOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/InternetExplorerDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/InternetExplorerDriver.cs
@@ -39,6 +39,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         public InternetExplorerDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -48,8 +49,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(internetExplorerOptions, BrowserType.InternetExplorer), projectName, jobName, disableReports, reportType, reportName, reportPath)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(internetExplorerOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/RemoteWebDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/RemoteWebDriver.cs
@@ -39,6 +39,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         public RemoteWebDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -48,8 +49,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(driverOptions, BrowserType.Remote), projectName, jobName, disableReports, reportType, reportName, reportPath)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(driverOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/SafariDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/SafariDriver.cs
@@ -39,6 +39,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
         public SafariDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -48,8 +49,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(safariOptions, BrowserType.Safari), projectName, jobName, disableReports, reportType, reportName, reportPath)
+            string reportPath = null,
+            TimeSpan? remoteConnectionTimeout = null)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(safariOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/AppiumCustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/AppiumCustomHttpCommandExecutor.cs
@@ -37,8 +37,9 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         /// </summary>
         /// <param name="addressOfRemoteServer">URL of the remote Selenium server managed by the Agent.</param>
         /// <param name="disableReports">True if all reporting should be disabled, false otherwise.</param>
-        public AppiumCustomHttpCommandExecutor(Uri addressOfRemoteServer, bool disableReports)
-            : base(addressOfRemoteServer, disableReports)
+        /// <param name="remoteConnectionTimeout">Timeout for the remote connection to the WebDriver server executing the commands.</param>
+        public AppiumCustomHttpCommandExecutor(Uri addressOfRemoteServer, bool disableReports, TimeSpan remoteConnectionTimeout)
+            : base(addressOfRemoteServer, disableReports, remoteConnectionTimeout)
         {
             this.skipReporting = disableReports;
         }

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/CustomHttpCommandExecutor.cs
@@ -52,7 +52,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         /// <param name="addressOfRemoteServer">URL of the remote Selenium server managed by the Agent.</param>
         /// <param name="disableReports">True if all reporting should be disabled, false otherwise.</param>
         public CustomHttpCommandExecutor(Uri addressOfRemoteServer, bool disableReports)
-            : this(addressOfRemoteServer, disableReports, TimeSpan.FromSeconds(10))
+            : this(addressOfRemoteServer, disableReports, TimeSpan.FromSeconds(60))
         {
         }
 

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -47,6 +47,11 @@ namespace TestProject.OpenSDK.Internal.Rest
     public class AgentClient
     {
         /// <summary>
+        /// Default remote connection timeout.
+        /// </summary>
+        internal static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(60);
+
+        /// <summary>
         /// Minimum Agent version that support session reuse.
         /// </summary>
         private static readonly Version MinSessionReuseCapableVersion = new Version("0.64.32");


### PR DESCRIPTION
While investigating https://github.com/testproject-io/csharp-opensdk/issues/170 it was discovered that the command can sometimes timeout, causing it to fail. This is because the default connection timeout was hard-coded to 10 seconds.
This MR does the following:

- Increase default connection timeout to 60 seconds.
- Allow overriding the remote connection timeout via driver constructor