### PR TITLE
Fixed the behavior where SendKeys would return NullPointerException

### DIFF
--- a/TestProject.OpenSDK/Internal/Helpers/RedactHelper.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/RedactHelper.cs
@@ -83,7 +83,7 @@ namespace TestProject.OpenSDK.Internal.Helpers
 
             Response response = executor.Execute(getAttributeCommand, true);
 
-            string inputType = response.Status.Equals(WebDriverResult.Success) ? response.Value.ToString() : string.Empty;
+            string inputType = response.Status.Equals(WebDriverResult.Success) ? (response.Value?.ToString() ?? string.Empty) : string.Empty;
 
             return inputType.Equals("password") || inputType.Equals("XCUIElementTypeSecureTextField");
         }


### PR DESCRIPTION
Added null check to the response value of "TestProjectCommandExecutor" when trying to check whether an element is a secured element