### PR TITLE
228 reports at batches

### DIFF
--- a/TestProject.OpenSDK/Exceptions/FailedReportException.cs
+++ b/TestProject.OpenSDK/Exceptions/FailedReportException.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="FailedReportException.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Exceptions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Exception object thrown when the SDK is failed to send reports to the agent.
+    /// </summary>
+    public class FailedReportException : Exception
+    {
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FailedReportException"/> class with the provided message.
+        /// </summary>
+        /// <param name="message">Exception message to be set.</param>
+        public FailedReportException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/ReportsQueue.cs
+++ b/TestProject.OpenSDK/Internal/ReportsQueue.cs
@@ -161,7 +161,7 @@ namespace TestProject.OpenSDK.Internal
                     return;
                 }
 
-                Logger.Warn($"Agent responded with an unexpected status {(int)response.StatusCode} with message: {response.ErrorMessage}.");
+                Logger.Warn($"Agent responded with an unexpected status {response?.StatusCode ?? 0} during the report: {response?.ErrorMessage ?? "No message."}.");
                 Logger.Info($"Attempt to send report again to the Agent. {reportAttemptsCount - 1} more attempts are left.");
             }
 

--- a/TestProject.OpenSDK/Internal/ReportsQueue.cs
+++ b/TestProject.OpenSDK/Internal/ReportsQueue.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Internal
     using System.Threading;
     using NLog;
     using RestSharp;
+    using TestProject.OpenSDK.Exceptions;
     using TestProject.OpenSDK.Internal.Rest.Messages;
 
     /// <summary>
@@ -28,19 +29,29 @@ namespace TestProject.OpenSDK.Internal
     public class ReportsQueue
     {
         /// <summary>
-        /// Maximum amount of time to wait in milliseconds before forcibly terminating the queue.
+        /// In case of failure during report - attempt maximum 4 times.
         /// </summary>
-        private const int REPORTS_QUEUE_TIMEOUT = 10000;
-
-        /// <summary>
-        /// HTTP client used to send reports to the Agent.
-        /// </summary>
-        private RestClient client;
+        protected const int MaxReportFailureAttempts = 4;
 
         /// <summary>
         /// Queue that will hold the items to be reported.
         /// </summary>
-        private BlockingCollection<QueueItem> reportItems = new BlockingCollection<QueueItem>();
+        protected BlockingCollection<QueueItem> ReportItems { get; } = new BlockingCollection<QueueItem>();
+
+        /// <summary>
+        /// HTTP client used to send reports to the Agent.
+        /// </summary>
+        protected RestClient Client { get; set; }
+
+        /// <summary>
+        /// A flag that is raised when all attempts submitting a report fail.
+        /// </summary>
+        protected bool StopReports { get; set; } = false;
+
+        /// <summary>
+        /// Maximum amount of time to wait in milliseconds before forcibly terminating the queue.
+        /// </summary>
+        private const int REPORTS_QUEUE_TIMEOUT = 10000;
 
         /// <summary>
         /// Thread that will take care of reporting while test execution continues.
@@ -63,7 +74,7 @@ namespace TestProject.OpenSDK.Internal
         /// <param name="client">The <see cref="RestClient"/> HTTP client to send reports to the Agent.</param>
         public ReportsQueue(RestClient client)
         {
-            this.client = client;
+            this.Client = client;
             this.reporterThread = new Thread(new ThreadStart(this.Worker));
             this.reporterThread.IsBackground = true;
             this.reporterThread.Start();
@@ -76,7 +87,10 @@ namespace TestProject.OpenSDK.Internal
         /// <param name="report">The report that this HTTP request contains.</param>
         public void Submit(RestRequest request, Report report)
         {
-            this.reportItems.Add(new QueueItem(request, report));
+            if (!this.StopReports)
+            {
+                this.ReportItems.Add(new QueueItem(request, report));
+            }
         }
 
         /// <summary>
@@ -86,17 +100,75 @@ namespace TestProject.OpenSDK.Internal
         {
             this.running = false;
 
-            this.reportItems.Add(new QueueItem(null, null));
+            this.ReportItems.Add(new QueueItem(null, null));
 
-            this.reportItems.CompleteAdding();
+            this.ReportItems.CompleteAdding();
 
             // Wait until all pending items are reported or the timeout has been reached.
-            bool reportingCompleted = SpinWait.SpinUntil(() => this.reportItems.Count == 0, REPORTS_QUEUE_TIMEOUT);
+            bool reportingCompleted = SpinWait.SpinUntil(() => this.ReportItems.Count == 0, REPORTS_QUEUE_TIMEOUT);
 
             if (!reportingCompleted)
             {
-                Logger.Warn($"There are {this.reportItems.Count} unreported items left in the queue.");
+                Logger.Warn($"There are {this.ReportItems.Count} unreported items left in the queue.");
             }
+        }
+
+        /// <summary>
+        ///  Handle the report.
+        ///  From version 3.1.0 -> send reports in batches.
+        ///  For lower versions -> Send standalone report.
+        /// </summary>
+        protected virtual void HandleReport()
+        {
+            foreach (QueueItem itemToReport in this.ReportItems.GetConsumingEnumerable(CancellationToken.None))
+            {
+                if (itemToReport.Request == null && itemToReport.Report == null)
+                {
+                    if (this.running)
+                    {
+                        // These nulls are not OK, something went wrong preparing the report/request.
+                        Logger.Error("An empty request and report were submitted to the queue");
+                    }
+
+                    // These nulls are OK, they were added by stop() method on purpose.
+                    return;
+                }
+
+                this.SendReport(itemToReport.Request);
+            }
+        }
+
+        /// <summary>
+        /// Submits a report to the Agent.
+        /// </summary>
+        /// <param name="sendReportsBatchRequest"> Http request to send report to the agent.
+        /// For lower versions than 3.1.0 -> HTTP request retrieved from the queue.
+        /// For versions 3.1.0 and greater -> Build reports batch HTTP request.
+        /// </param>
+        /// <exception>FailedReportException if cannot send report to the agent more than <see cref="MaxReportFailureAttempts"/> attempts.</exception>
+        protected void SendReport(RestRequest sendReportsBatchRequest)
+        {
+            IRestResponse response;
+            int reportAttemptsCount;
+            for (reportAttemptsCount = MaxReportFailureAttempts; reportAttemptsCount > 0; reportAttemptsCount--)
+            {
+                response = this.Client.Execute(sendReportsBatchRequest);
+
+                // If the reports were sent successfully, there is no need to continue to the rest of the code
+                // since it's handling unsuccessful response.
+                if (response != null && response.IsSuccessful)
+                {
+                    return;
+                }
+
+                Logger.Warn($"Agent responded with an unexpected status {(int)response.StatusCode} with message: {response.ErrorMessage}.");
+                Logger.Info($"Attempt to send report again to the Agent. {reportAttemptsCount - 1} more attempts are left.");
+            }
+
+            // In case all attepts to send the report are failed.
+            // If the report has been sent successfully - this code will not execute.
+            Logger.Error($"All {MaxReportFailureAttempts} attempts to send report have failed.");
+            throw new FailedReportException($"All {MaxReportFailureAttempts} attempts to send report have failed.");
         }
 
         /// <summary>
@@ -106,38 +178,16 @@ namespace TestProject.OpenSDK.Internal
         {
             this.running = true;
 
-            while (this.running || this.reportItems.Count > 0)
+            while (this.running || this.ReportItems.Count > 0)
             {
-                foreach (QueueItem itemToReport in this.reportItems.GetConsumingEnumerable(CancellationToken.None))
+                try
                 {
-                    this.SendReport(itemToReport);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Submits a report to the Agent.
-        /// </summary>
-        /// <param name="itemToReport">The <see cref="QueueItem"/> to report to the Agent.</param>
-        private void SendReport(QueueItem itemToReport)
-        {
-            if (itemToReport.Request == null && itemToReport.Report == null)
-            {
-                if (this.running)
+                    this.HandleReport();
+                } catch (FailedReportException)
                 {
-                    // These nulls are not OK, something went wrong preparing the report/request.
-                    Logger.Error("An empty request and report were submitted to the queue");
+                    this.StopReports = true;
+                    Logger.Warn("Reports are disabled due to multiple failed attempts of sending reports to the agent.");
                 }
-
-                // These nulls are OK, they were added by stop() method on purpose.
-                return;
-            }
-
-            IRestResponse response = this.client.Execute(itemToReport.Request);
-
-            if ((int)response.StatusCode >= 400)
-            {
-                Logger.Error($"Agent returned HTTP {(int)response.StatusCode} with message: {response.ErrorMessage}");
             }
         }
 

--- a/TestProject.OpenSDK/Internal/ReportsQueueBatch.cs
+++ b/TestProject.OpenSDK/Internal/ReportsQueueBatch.cs
@@ -1,0 +1,121 @@
+﻿// <copyright file="ReportsQueueBatch.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using NLog;
+    using RestSharp;
+    using TestProject.OpenSDK.Exceptions;
+    using TestProject.OpenSDK.Internal.Helpers;
+    using TestProject.OpenSDK.Internal.Rest.Messages;
+    using static TestProject.OpenSDK.Internal.Rest.AgentClient;
+
+    /// <summary>
+    /// A queue class managing the sending of report items to the Agent in a separate thread.
+    /// This queue class sending reports as batches instead of sending reports one by one.
+    /// </summary>
+    public class ReportsQueueBatch : ReportsQueue
+    {
+        /// <summary>
+        /// Default batch report size is maximum 10 reports.
+        /// </summary>
+        private const int MaxReportsBatchSize = 10;
+
+        /// <summary>
+        /// Name of the environment variable that stores the max reports batch size.
+        /// Default value of <see cref="MaxReportsBatchSize"> can be override by this environment variable.
+        /// </summary>
+        private const string TpMaxBatchSize = "TP_MAX_BATCH_SIZE";
+
+        /// <summary>
+        /// The max batch size used in reports batch creation.
+        /// In case environment variable <see cref="tpMaxBatchSize"> was defined - this will be the batch size.
+        /// Default value defined as <see cref="MaxReportsBatchSize">.
+        /// </summary>
+        private readonly int maxBatchSize;
+
+        /// <summary>
+        /// Logger instance for this class.
+        /// </summary>
+        private static Logger Logger { get; set; } = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// Configuration settings for (de-)serializing objects to / from JSON.
+        /// This configuration is needed because the type field we send to the agent should be Pascal case instead of camel case.
+        /// </summary>
+        private JsonSerializerSettings serializerSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReportsQueueBatch"/> class.
+        /// </summary>
+        /// <param name="client">The <see cref="RestClient"/> HTTP client to send reports to the Agent.</param>
+        public ReportsQueueBatch(RestClient client)
+            : base(client)
+        {
+            this.serializerSettings = CustomJsonSerializer.Populate(new JsonSerializerSettings());
+
+            // Override default converter of enum to string since agent is case sensitive.
+            this.serializerSettings.Converters.Clear();
+            this.serializerSettings.Converters.Add(new StringEnumConverter());
+
+            // Try to get maximum report batch size from env variable.
+            string tpMaxBatchSizeEnvVal = Environment.GetEnvironmentVariable(TpMaxBatchSize);
+            this.maxBatchSize = (tpMaxBatchSizeEnvVal != null) ? int.Parse(tpMaxBatchSizeEnvVal) : MaxReportsBatchSize;
+        }
+
+        /// <summary>
+        ///  Overriding the base method to handle reports at batches.
+        ///  While there are reports in the queue - collect up to 10 reports and send them at batch.
+        /// </summary>
+        /// <exception>FailedReportException if cannot send report to the agent more than <see cref="MaxReportFailureAttempts"/> attempts.</exception>
+        protected override void HandleReport()
+        {
+            // LinkedList to store the reports batch before sending them.
+            LinkedList<Report> batchReports = new LinkedList<Report>();
+
+            // Extract and remove up to 10 items or till queue is empty from queue - without blocking it.
+            while (this.ReportItems.Count > 0 && batchReports.Count < this.maxBatchSize)
+            {
+                QueueItem item;
+
+                // Get the first item in the queue without blocking it.
+                bool taken = this.ReportItems.TryTake(out item);
+
+                if (taken && item != null && item.Report != null)
+                {
+                    batchReports.AddLast(item.Report);
+                }
+            }
+
+            if (batchReports.Count == 0)
+            {
+                return;
+            }
+
+            // Build REST request.
+            RestRequest sendReportsBatchRequest = new RestRequest(Endpoints.REPORT_BATCH, Method.POST);
+            sendReportsBatchRequest.RequestFormat = DataFormat.Json;
+            string json = CustomJsonSerializer.ToJson(batchReports, this.serializerSettings);
+            sendReportsBatchRequest.AddJsonBody(json);
+
+            this.SendReport(sendReportsBatchRequest);
+        }
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -57,6 +57,11 @@ namespace TestProject.OpenSDK.Internal.Rest
         private static readonly Version MinSessionReuseCapableVersion = new Version("0.64.32");
 
         /// <summary>
+        /// Minimum Agent version that supports reporting at batches.
+        /// </summary>
+        private static readonly Version MinBatchReportSupportedVersion = new Version("3.1.0");
+
+        /// <summary>
         /// The current version of the Agent in use.
         /// </summary>
         private static Version agentVersion;
@@ -256,12 +261,12 @@ namespace TestProject.OpenSDK.Internal.Rest
 
             this.serializerSettings = CustomJsonSerializer.Populate(new JsonSerializerSettings());
 
+            agentVersion = this.GetAgentVersion();
+
             // Check that Agent version supports the requested feature.
             if (compatibleVersion != null)
             {
                 Logger.Trace($"Checking if the Agent version is {compatibleVersion} at minimum");
-
-                agentVersion = this.GetAgentVersion();
 
                 if (agentVersion.CompareTo(compatibleVersion) < 0)
                 {
@@ -270,7 +275,8 @@ namespace TestProject.OpenSDK.Internal.Rest
                 }
             }
 
-            this.reportsQueue = new ReportsQueue(this.client);
+            // Create the relevant ReportsQueue according agentVersion in order to handle reports.
+            this.reportsQueue = (agentVersion.CompareTo(MinBatchReportSupportedVersion) > 0) ? new ReportsQueueBatch(this.client) : new ReportsQueue(this.client);
 
             this.StartSession(sessionReportSettings, capabilities);
 

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -735,6 +735,11 @@ namespace TestProject.OpenSDK.Internal.Rest
             public const string REPORT_STEP = "/api/development/report/step";
 
             /// <summary>
+            /// Endpoint for reporting a batch.
+            /// </summary>
+            public const string REPORT_BATCH = "/api/development/report/batch";
+
+            /// <summary>
             /// Endpoint for execution action proxies.
             /// </summary>
             public const string EXECUTE_ACTION_PROXY = "/api/addons/executions";

--- a/TestProject.OpenSDK/Internal/Rest/Messages/DriverCommandReport.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/DriverCommandReport.cs
@@ -17,12 +17,19 @@
 namespace TestProject.OpenSDK.Internal.Rest.Messages
 {
     using System.Collections.Generic;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Payload object sent to the Agent to report a WebDriver command.
     /// </summary>
     public class DriverCommandReport : Report
     {
+        /// <summary>
+        /// Define type as Test for batch report support.
+        /// </summary>
+        [JsonProperty("type")]
+        private const ReportItemType Type = ReportItemType.Command;
+
         /// <summary>
         /// WebDriver command executed by the driver.
         /// </summary>

--- a/TestProject.OpenSDK/Internal/Rest/Messages/ReportItemType.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/ReportItemType.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="SessionRequest.cs" company="TestProject">
+// Copyright 2020 TestProject (https://testproject.io)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestProject.OpenSDK.Internal.Rest.Messages
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Those are the reports types which are supported to be sent at batches.
+    /// </summary>
+    public enum ReportItemType
+    {
+        /// <summary>
+        /// Represent command report.
+        /// </summary>
+        Command,
+
+        /// <summary>
+        /// Represent test report.
+        /// </summary>
+        Test,
+
+        /// <summary>
+        /// Represent step report.
+        /// </summary>
+        Step,
+    }
+}

--- a/TestProject.OpenSDK/Internal/Rest/Messages/StepReport.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/StepReport.cs
@@ -16,11 +16,19 @@
 
 namespace TestProject.OpenSDK.Internal.Rest.Messages
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Payload object sent to the Agent when reporting a test step.
     /// </summary>
     public class StepReport : Report
     {
+        /// <summary>
+        /// Define type as Test for batch report support.
+        /// </summary>
+        [JsonProperty("type")]
+        private const ReportItemType Type = ReportItemType.Step;
+
         /// <summary>
         /// A GUID that uniquely identifies this step.
         /// </summary>

--- a/TestProject.OpenSDK/Internal/Rest/Messages/TestReport.cs
+++ b/TestProject.OpenSDK/Internal/Rest/Messages/TestReport.cs
@@ -16,11 +16,19 @@
 
 namespace TestProject.OpenSDK.Internal.Rest.Messages
 {
+    using Newtonsoft.Json;
+
     /// <summary>
     /// Payload object sent to the Agent when reporting a test.
     /// </summary>
     public class TestReport : Report
     {
+        /// <summary>
+        /// Define type as Test for batch report support.
+        /// </summary>
+        [JsonProperty("type")]
+        private const ReportItemType Type = ReportItemType.Test;
+
         /// <summary>
         /// The test name.
         /// </summary>


### PR DESCRIPTION
Adding logic to support reporting at batches due to issue #228 
ReportsQueueBatch was added to support up to 10 reports in a batch.
Logic added to AgentClient - to support the new ReportsQueue from agent version: 3.0.0  