### PR TITLE
feat: Rename environment variable.

### DIFF
--- a/TestProject.OpenSDK/Internal/ReportsQueueBatch.cs
+++ b/TestProject.OpenSDK/Internal/ReportsQueueBatch.cs
@@ -42,7 +42,7 @@ namespace TestProject.OpenSDK.Internal
         /// Name of the environment variable that stores the max reports batch size.
         /// Default value of <see cref="MaxReportsBatchSize"> can be override by this environment variable.
         /// </summary>
-        private const string TpMaxBatchSize = "TP_MAX_BATCH_SIZE";
+        private const string TpMaxBatchSizeVariableName = "TP_MAX_REPORTS_BATCH_SIZE";
 
         /// <summary>
         /// The max batch size used in reports batch creation.
@@ -76,7 +76,7 @@ namespace TestProject.OpenSDK.Internal
             this.serializerSettings.Converters.Add(new StringEnumConverter());
 
             // Try to get maximum report batch size from env variable.
-            string tpMaxBatchSizeEnvVal = Environment.GetEnvironmentVariable(TpMaxBatchSize);
+            string tpMaxBatchSizeEnvVal = Environment.GetEnvironmentVariable(TpMaxBatchSizeVariableName);
             this.maxBatchSize = (tpMaxBatchSizeEnvVal != null) ? int.Parse(tpMaxBatchSizeEnvVal) : MaxReportsBatchSize;
         }
 

--- a/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
+++ b/TestProject.OpenSDK/Internal/Rest/AgentClient.cs
@@ -276,7 +276,7 @@ namespace TestProject.OpenSDK.Internal.Rest
             }
 
             // Create the relevant ReportsQueue according agentVersion in order to handle reports.
-            this.reportsQueue = (agentVersion.CompareTo(MinBatchReportSupportedVersion) > 0) ? new ReportsQueueBatch(this.client) : new ReportsQueue(this.client);
+            this.reportsQueue = (agentVersion.CompareTo(MinBatchReportSupportedVersion) >= 0) ? new ReportsQueueBatch(this.client) : new ReportsQueue(this.client);
 
             this.StartSession(sessionReportSettings, capabilities);
 


### PR DESCRIPTION
This PR is fixing development feature: #228.
1) Renaming the environment variable of maximum reports batch size to TP_MAX_REPORTS_BATCH_SIZE instead of TP_MAX_BATCH_SIZE. 

2) Fixing ReportsQueue creation condition.
Feature #228 should support agent version 3.1.0 (including) and above. 
Due to an incorrect condition, version 3.1.0 was not supported. 



Signed-off-by: oriddd <ori.dafna@testproject.io>