### PR TITLE
Fix issues related with element.Displayed checks

### DIFF
--- a/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
+++ b/TestProject.OpenSDK/Internal/CallStackAnalysis/StackTraceHelper.cs
@@ -100,6 +100,22 @@ namespace TestProject.OpenSDK.Internal.CallStackAnalysis
         }
 
         /// <summary>
+        /// Checks whether we are running inside an InvisibilityCondition
+        /// </summary>
+        /// <returns></returns>
+        public bool IsInvisibleCondition()
+        {
+            return new StackTrace().GetFrames()
+                .Any(f =>
+                {
+                    var declaringType = f.GetMethod().DeclaringType;
+                    return declaringType != null &&
+                           declaringType.FullName.Contains(".ExpectedConditions") &&
+                           f.GetMethod().Name.StartsWith("<InvisibilityOfElement");
+                });
+        }
+
+        /// <summary>
         /// Checks if we're running inside a SpecFlow scenario.
         /// </summary>
         /// <returns>True if a SpecFlow reference is found in the stack trace, false otherwise.</returns>

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
@@ -17,6 +17,7 @@
 namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
 {
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using NLog;
     using OpenQA.Selenium.Remote;
     using TestProject.OpenSDK.Enums;
@@ -51,7 +52,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
 
         private ITestProjectCommandExecutor commandExecutor;
 
-        private SortedDictionary<string, StashedCommand> stashedCommands;
+        private OrderedDictionary stashedCommands;
 
         private string currentTestName;
 
@@ -67,7 +68,7 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         /// <param name="disableReports">True if all reporting should be disabled, false otherwise.</param>
         public ReportingCommandExecutor(ITestProjectCommandExecutor commandExecutor, bool disableReports)
         {
-            this.stashedCommands = new SortedDictionary<string, StashedCommand>();
+            this.stashedCommands = new OrderedDictionary();
             this.commandExecutor = commandExecutor;
             this.ReportsDisabled = disableReports;
         }
@@ -124,9 +125,9 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
         {
             if (this.stashedCommands.Count > 0)
             {
-                foreach (var keyValuePair in this.stashedCommands)
+                foreach (DictionaryEntry keyValuePair in this.stashedCommands)
                 {
-                    var command = keyValuePair.Value;
+                    var command = (StashedCommand)keyValuePair.Value;
                     this.SendCommandToAgent(command.Command, command.Result, command.Passed);
                 }
 

--- a/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
+++ b/TestProject.OpenSDK/Internal/Helpers/CommandExecutors/ReportingCommandExecutor.cs
@@ -101,11 +101,19 @@ namespace TestProject.OpenSDK.Internal.Helpers.CommandExecutors
                 return;
             }
 
+            // If the command is IsDisplayed, the passed value we report to agent should be whether the element is visible or not.
+            bool passed = response.IsPassed();
+            if (CommandHelper.IsDisplayedCommand(command) && passed)
+            {
+                passed = bool.Parse(response.Value.ToString());
+            }
+
             if (StackTraceHelper.Instance.IsRunningInsideWait())
             {
                 // Save the command
                 var stashedCommand = new StashedCommand(command, response.Value, response.IsPassed());
                 this.stashedCommands[$"{command}_{response.IsPassed()}"] = stashedCommand;
+                var stashedCommand = new StashedCommand(command, response.Value, passed);
 
                 // Do not report the command right away if it's executed inside a WebDriverWait
                 return;


### PR DESCRIPTION
We have several issues related to the way we treat the result of `element.Displayed` (#208 and #232). In other SDK's, the pass/fail value of reported test is based on the element's visibility rather than the command success. This PR will set the pass/fail value based on the following:

- Element's visibility
- Fluent wait with invisibility expected condition