### PR TITLE
fix: make connection timeout with the agent configurable

### DIFF
--- a/.github/ci/docker-compose.yml
+++ b/.github/ci/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "5555:4444"
   firefox:
-    image: selenium/standalone-firefox
+    image: selenium/standalone-firefox:92.0
     volumes:
       - /dev/shm:/dev/shm
     ports:

--- a/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Android/AndroidDriver.cs
@@ -73,6 +73,7 @@ namespace TestProject.OpenSDK.Drivers.Android
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">Timeout for the remote connection to the WebDriver server executing the commands.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public AndroidDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -83,9 +84,10 @@ namespace TestProject.OpenSDK.Drivers.Android
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
             : base(
-                  AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports).AgentSession.RemoteAddress,
+                  AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports, restClientTimeout).AgentSession.RemoteAddress,
                   AgentClient.GetInstance().AgentSession.Capabilities,
                   remoteConnectionTimeout ?? DefaultCommandTimeout)
         {

--- a/TestProject.OpenSDK/Drivers/BaseDriver.cs
+++ b/TestProject.OpenSDK/Drivers/BaseDriver.cs
@@ -71,6 +71,7 @@ namespace TestProject.OpenSDK.Drivers
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         protected BaseDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -81,9 +82,10 @@ namespace TestProject.OpenSDK.Drivers
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
             : base(
-                  AgentClient.GetInstance(remoteAddress, token, driverOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports).AgentSession.Capabilities)
+                  AgentClient.GetInstance(remoteAddress, token, driverOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports, restClientTimeout).AgentSession.Capabilities)
         {
             this.sessionId = AgentClient.GetInstance().AgentSession.SessionId;
 

--- a/TestProject.OpenSDK/Drivers/DriverBuilder.cs
+++ b/TestProject.OpenSDK/Drivers/DriverBuilder.cs
@@ -83,6 +83,11 @@ namespace TestProject.OpenSDK.Drivers
         private TimeSpan? remoteConnectionTimeout;
 
         /// <summary>
+        /// The connection timeout to the agent in milliseconds.
+        /// </summary>
+        private int builderSocketSessionTimeout;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DriverBuilder{T}"/> class.
         /// </summary>
         /// <param name="options">See <see cref="DriverOptions"/> for more details.</param>
@@ -202,6 +207,18 @@ namespace TestProject.OpenSDK.Drivers
             return this;
         }
 
+
+        /// <summary>
+        /// Set the connection timeout to the agent in milliseconds.
+        /// </summary>
+        /// <param name="sessionSocketTimeout">timeout to the agent in milliseconds.</param>
+        /// <returns>Modified DriverBuilder instance.</returns>
+        public DriverBuilder<T> WithSessionSocketTimeout(int sessionSocketTimeout)
+        {
+            this.builderSocketSessionTimeout = sessionSocketTimeout;
+            return this;
+        }
+
         /// <summary>
         /// Builds an instance of the requested driver using set values.
         /// </summary>
@@ -221,7 +238,8 @@ namespace TestProject.OpenSDK.Drivers
                     this.builderReportType,
                     this.builderReportName,
                     this.builderReportPath,
-                    this.remoteConnectionTimeout);
+                    this.remoteConnectionTimeout,
+                    this.builderSocketSessionTimeout);
             } catch (Exception e)
             {
                 throw new WebDriverException($"Failed to create an instance of {typeof(T)}", e);

--- a/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Generic/GenericDriver.cs
@@ -61,6 +61,7 @@ namespace TestProject.OpenSDK.Drivers.Generic
         /// <param name="reportType">The report type of the execution, can be local, cloud or both.</param>
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public GenericDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -69,9 +70,10 @@ namespace TestProject.OpenSDK.Drivers.Generic
             bool disableReports = false,
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
-            string reportPath = null)
+            string reportPath = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
         {
-            AgentClient agentClient = AgentClient.GetInstance(remoteAddress, token, new GenericOptions(), new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports, this.minGenericDriverSupportedVersion);
+            AgentClient agentClient = AgentClient.GetInstance(remoteAddress, token, new GenericOptions(), new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports, restClientTimeout, this.minGenericDriverSupportedVersion);
 
             this.commandExecutor = new GenericCommandExecutor(remoteAddress, disableReports);
 

--- a/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
+++ b/TestProject.OpenSDK/Drivers/IOS/IOSDriver.cs
@@ -73,6 +73,7 @@ namespace TestProject.OpenSDK.Drivers.IOS
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">Timeout for the remote connection to the WebDriver server executing the commands.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public IOSDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -83,9 +84,10 @@ namespace TestProject.OpenSDK.Drivers.IOS
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
             : base(
-                  AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports).AgentSession.RemoteAddress,
+                  AgentClient.GetInstance(remoteAddress, token, appiumOptions, new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports, restClientTimeout).AgentSession.RemoteAddress,
                   AgentClient.GetInstance().AgentSession.Capabilities,
                   remoteConnectionTimeout ?? DefaultCommandTimeout)
         {

--- a/TestProject.OpenSDK/Drivers/Web/ChromeDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/ChromeDriver.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Drivers.Web
     using OpenQA.Selenium.Chrome;
     using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// Extension of <see cref="OpenQA.Selenium.Chrome.ChromeDriver">ChromeDriver</see> for use with TestProject.
@@ -40,6 +41,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public ChromeDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -50,8 +52,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(chromeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(chromeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout, restClientTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/EdgeDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/EdgeDriver.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Drivers.Web
     using OpenQA.Selenium.Edge;
     using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// Extension of <see cref="OpenQA.Selenium.Edge.EdgeDriver">EdgeDriver</see> for use with TestProject.
@@ -40,6 +41,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public EdgeDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -50,8 +52,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(edgeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(edgeOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout, restClientTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/FirefoxDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/FirefoxDriver.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Drivers.Web
     using OpenQA.Selenium.Firefox;
     using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// Extension of <see cref="OpenQA.Selenium.Firefox.FirefoxDriver">FirefoxDriver</see> for use with TestProject.
@@ -40,6 +41,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public FirefoxDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -50,8 +52,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(firefoxOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(firefoxOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout, restClientTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/InternetExplorerDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/InternetExplorerDriver.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Drivers.Web
     using OpenQA.Selenium.IE;
     using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// Extension of <see cref="OpenQA.Selenium.IE.InternetExplorerDriver">InternetExplorerDriver</see> for use with TestProject.
@@ -40,6 +41,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public InternetExplorerDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -50,8 +52,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(internetExplorerOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(internetExplorerOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout, restClientTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/RemoteWebDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/RemoteWebDriver.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Drivers.Web
     using OpenQA.Selenium;
     using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// Extension of <see cref="OpenQA.Selenium.Remote.RemoteWebDriver">RemoteWebDriver</see> for use with TestProject.
@@ -40,6 +41,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public RemoteWebDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -50,8 +52,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(driverOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(driverOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout, restClientTimeout)
         {
         }
     }

--- a/TestProject.OpenSDK/Drivers/Web/SafariDriver.cs
+++ b/TestProject.OpenSDK/Drivers/Web/SafariDriver.cs
@@ -20,6 +20,7 @@ namespace TestProject.OpenSDK.Drivers.Web
     using OpenQA.Selenium.Safari;
     using TestProject.OpenSDK.Enums;
     using TestProject.OpenSDK.Internal.Helpers.DriverOptions;
+    using TestProject.OpenSDK.Internal.Rest;
 
     /// <summary>
     /// Extension of <see cref="OpenQA.Selenium.Safari.SafariDriver">SafariDriver</see> for use with TestProject.
@@ -40,6 +41,7 @@ namespace TestProject.OpenSDK.Drivers.Web
         /// <param name="reportName">The name of the local generated report.</param>
         /// <param name="reportPath">The path of the local generated report.</param>
         /// <param name="remoteConnectionTimeout">The remote connection timeout to the server. Default is 60 seconds.</param>
+        /// <param name="restClientTimeout"> The connection timeout to the agent in milliseconds. Default is 120 seconds.</param>
         public SafariDriver(
             Uri remoteAddress = null,
             string token = null,
@@ -50,8 +52,9 @@ namespace TestProject.OpenSDK.Drivers.Web
             ReportType reportType = ReportType.CLOUD_AND_LOCAL,
             string reportName = null,
             string reportPath = null,
-            TimeSpan? remoteConnectionTimeout = null)
-            : base(remoteAddress, token, DriverOptionsHelper.Patch(safariOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout)
+            TimeSpan? remoteConnectionTimeout = null,
+            int restClientTimeout = AgentClient.DefaultRestClientTimeoutInMilliseconds)
+            : base(remoteAddress, token, DriverOptionsHelper.Patch(safariOptions, BrowserType.Chrome), projectName, jobName, disableReports, reportType, reportName, reportPath, remoteConnectionTimeout, restClientTimeout)
         {
         }
     }


### PR DESCRIPTION
Allow users configure the connection timeout (in millis) with the agent via the driver constructor