### PR TITLE
Update dependencies

### DIFF
--- a/TestProject.OpenSDK.SpecFlowExamples/TestProject.OpenSDK.SpecFlowExamples.csproj
+++ b/TestProject.OpenSDK.SpecFlowExamples/TestProject.OpenSDK.SpecFlowExamples.csproj
@@ -7,11 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.5.14" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.5.14" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.9.40" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestProject.OpenSDK.SpecFlowPlugin/TestProject.OpenSDK.SpecFlowPlugin.csproj
+++ b/TestProject.OpenSDK.SpecFlowPlugin/TestProject.OpenSDK.SpecFlowPlugin.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
@@ -25,8 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.6" />
-    <PackageReference Include="SpecFlow" Version="3.5.5" />
+    <PackageReference Include="NLog" Version="4.7.13" />
+    <PackageReference Include="SpecFlow" Version="3.9.40" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestProject.OpenSDK.Tests/TestProject.OpenSDK.Tests.csproj
+++ b/TestProject.OpenSDK.Tests/TestProject.OpenSDK.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/TestProject.OpenSDK/TestProject.OpenSDK.csproj
+++ b/TestProject.OpenSDK/TestProject.OpenSDK.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -23,9 +23,9 @@ From now on, you can effortlessly execute Selenium and Appium native tests using
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.7.5" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="NLog" Version="4.7.13" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Many dependencies used by the OpenSDK are several months old at this point and should have been updated a long time ago
As an example, SpecFlow now has 3.9.40, where we would use version 3.5.5